### PR TITLE
Strict

### DIFF
--- a/src/build_macros.rs
+++ b/src/build_macros.rs
@@ -28,6 +28,16 @@ macro_rules! optional_dict_get {
 }
 pub(crate) use optional_dict_get;
 
+macro_rules! is_strict {
+    ($schema:ident, $config:ident) => {
+        match crate::build_macros::dict_get!($schema, "strict", bool) {
+            Some(v) => v,
+            None => crate::build_macros::optional_dict_get!($config, "strict", bool).unwrap_or(false),
+        }
+    };
+}
+pub(crate) use is_strict;
+
 macro_rules! dict {
     ($py:ident, $($k:expr => $v:expr),*) => {{
         pyo3::types::IntoPyDict::into_py_dict([$(($k, $v.into_py($py)),)*], $py).into()

--- a/src/build_macros.rs
+++ b/src/build_macros.rs
@@ -18,6 +18,16 @@ macro_rules! dict_get_required {
 }
 pub(crate) use dict_get_required;
 
+macro_rules! optional_dict_get {
+    ($optional_dict:ident, $key:expr, $type:ty) => {
+        match $optional_dict {
+            Some(d) => crate::build_macros::dict_get!(d, $key, $type),
+            None => None,
+        }
+    };
+}
+pub(crate) use optional_dict_get;
+
 macro_rules! dict {
     ($py:ident, $($k:expr => $v:expr),*) => {{
         pyo3::types::IntoPyDict::into_py_dict([$(($k, $v.into_py($py)),)*], $py).into()

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -7,6 +7,7 @@ pub enum ErrorKind {
     InvalidInput,
     #[strum(message = "Invalid JSON")]
     InvalidJson,
+    // ---------------------
     // model specific errors
     #[strum(message = "Field required")]
     Missing,
@@ -16,15 +17,15 @@ pub enum ErrorKind {
     InvalidKey,
     #[strum(message = "Value must be an instance of {class_name}")]
     ModelType,
+    // ---------------------
     // None errors
     #[strum(message = "Value must not be None/null")]
-    NoneForbidden,
-    #[strum(message = "Value must be None/null")]
     NoneRequired,
     // boolean errors
     #[strum(message = "Value must be a valid boolean")]
     Bool,
     #[strum(message = "Value must be a valid string")]
+    // ---------------------
     // string errors
     StrType,
     #[strum(message = "Value must be a valid string, unable to parse raw data as a unicode string")]
@@ -35,6 +36,7 @@ pub enum ErrorKind {
     StrTooLong,
     #[strum(message = "String must match pattern '{pattern}'")]
     StrPatternMismatch,
+    // ---------------------
     // dict errors
     #[strum(message = "Value must be a valid dictionary")]
     DictType,
@@ -46,6 +48,7 @@ pub enum ErrorKind {
     DictTooShort,
     #[strum(message = "Dictionary must have at most {max_length} items")]
     DictTooLong,
+    // ---------------------
     // list errors
     #[strum(message = "Value must be a valid list/array")]
     ListType,
@@ -53,11 +56,13 @@ pub enum ErrorKind {
     ListTooShort,
     #[strum(message = "List must have at most {max_length} items")]
     ListTooLong,
+    // ---------------------
     // bool errors
     #[strum(message = "Value must be a valid boolean")]
     BoolType,
     #[strum(message = "Value must be a valid boolean, unable to interpret input")]
     BoolParsing,
+    // ---------------------
     // int errors
     #[strum(message = "Value must be a valid integer")]
     IntType,
@@ -75,6 +80,7 @@ pub enum ErrorKind {
     IntLessThan,
     #[strum(message = "Value must be less than or equal to {le}")]
     IntLessThanEqual,
+    // ---------------------
     // float errors
     #[strum(message = "Value must be a valid number")]
     FloatType,
@@ -90,6 +96,7 @@ pub enum ErrorKind {
     FloatLessThan,
     #[strum(message = "Value must be less than or equal to {le}")]
     FloatLessThanEqual,
+    // ---------------------
     // python errors from functions (the messages here will not be used as we sett message in these cases)
     #[strum(message = "Invalid value")]
     ValueError,

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -14,6 +14,8 @@ pub enum ErrorKind {
     ExtraForbidden,
     #[strum(message = "Model keys must be strings")]
     InvalidKey,
+    #[strum(message = "Value must be an instance of {class_name}")]
+    ModelType,
     // None errors
     #[strum(message = "Value must not be None/null")]
     NoneForbidden,

--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -10,10 +10,6 @@ use super::shared::{int_as_bool, str_as_bool};
 use super::traits::{DictInput, Input, ListInput, ToLocItem, ToPy};
 
 impl Input for Value {
-    fn is_direct_instance_of(&self, _class: &PyType) -> ValResult<bool> {
-        Ok(false)
-    }
-
     fn validate_none(&self, py: Python) -> ValResult<()> {
         match self {
             Value::Null => Ok(()),
@@ -21,7 +17,14 @@ impl Input for Value {
         }
     }
 
-    fn validate_str(&self, py: Python) -> ValResult<String> {
+    fn strict_str(&self, py: Python) -> ValResult<String> {
+        match self {
+            Value::String(s) => Ok(s.to_string()),
+            _ => err_val_error!(py, self, kind = ErrorKind::StrType),
+        }
+    }
+
+    fn lax_str(&self, py: Python) -> ValResult<String> {
         match self {
             Value::String(s) => Ok(s.to_string()),
             Value::Number(n) => Ok(n.to_string()),
@@ -29,7 +32,14 @@ impl Input for Value {
         }
     }
 
-    fn validate_bool(&self, py: Python) -> ValResult<bool> {
+    fn strict_bool(&self, py: Python) -> ValResult<bool> {
+        match self {
+            Value::Bool(b) => Ok(*b),
+            _ => err_val_error!(py, self, kind = ErrorKind::BoolType),
+        }
+    }
+
+    fn lax_bool(&self, py: Python) -> ValResult<bool> {
         match self {
             Value::Bool(b) => Ok(*b),
             Value::String(s) => str_as_bool(py, s),
@@ -44,7 +54,20 @@ impl Input for Value {
         }
     }
 
-    fn validate_int(&self, py: Python) -> ValResult<i64> {
+    fn strict_int(&self, py: Python) -> ValResult<i64> {
+        match self {
+            Value::Number(n) => {
+                if let Some(int) = n.as_i64() {
+                    Ok(int)
+                } else {
+                    err_val_error!(py, self, kind = ErrorKind::IntType)
+                }
+            }
+            _ => err_val_error!(py, self, kind = ErrorKind::IntType),
+        }
+    }
+
+    fn lax_int(&self, py: Python) -> ValResult<i64> {
         match self {
             Value::Number(n) => {
                 if let Some(int) = n.as_i64() {
@@ -67,7 +90,20 @@ impl Input for Value {
         }
     }
 
-    fn validate_float(&self, py: Python) -> ValResult<f64> {
+    fn strict_float(&self, py: Python) -> ValResult<f64> {
+        match self {
+            Value::Number(n) => {
+                if let Some(float) = n.as_f64() {
+                    Ok(float)
+                } else {
+                    err_val_error!(py, self, kind = ErrorKind::FloatParsing)
+                }
+            }
+            _ => err_val_error!(py, self, kind = ErrorKind::FloatType),
+        }
+    }
+
+    fn lax_float(&self, py: Python) -> ValResult<f64> {
         match self {
             Value::Number(n) => {
                 if let Some(float) = n.as_f64() {
@@ -84,18 +120,30 @@ impl Input for Value {
         }
     }
 
-    fn validate_dict<'py>(&'py self, py: Python<'py>, _try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+    fn strict_model_check(&self, _class: &PyType) -> ValResult<bool> {
+        Ok(false)
+    }
+
+    fn strict_dict<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
         match self {
             Value::Object(dict) => Ok(Box::new(dict)),
             _ => err_val_error!(py, self, kind = ErrorKind::DictType),
         }
     }
 
-    fn validate_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
+    fn lax_dict<'py>(&'py self, py: Python<'py>, _try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+        self.strict_dict(py)
+    }
+
+    fn strict_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
         match self {
             Value::Array(a) => Ok(Box::new(a)),
             _ => err_val_error!(py, self, kind = ErrorKind::ListType),
         }
+    }
+
+    fn lax_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
+        self.strict_list(py)
     }
 }
 
@@ -182,41 +230,65 @@ impl ToLocItem for Value {
 
 /// Required for Dict keys so the string can behave like an Input
 impl Input for String {
-    fn is_direct_instance_of(&self, _class: &PyType) -> ValResult<bool> {
-        Ok(false)
-    }
-
     fn validate_none(&self, py: Python) -> ValResult<()> {
         err_val_error!(py, self, kind = ErrorKind::NoneRequired)
     }
 
-    fn validate_str(&self, _py: Python) -> ValResult<String> {
+    fn strict_str(&self, _py: Python) -> ValResult<String> {
         Ok(self.clone())
     }
 
-    fn validate_bool(&self, py: Python) -> ValResult<bool> {
+    fn lax_str(&self, _py: Python) -> ValResult<String> {
+        Ok(self.clone())
+    }
+
+    fn strict_bool(&self, py: Python) -> ValResult<bool> {
+        err_val_error!(py, self, kind = ErrorKind::BoolType)
+    }
+
+    fn lax_bool(&self, py: Python) -> ValResult<bool> {
         str_as_bool(py, self)
     }
 
-    fn validate_int(&self, py: Python) -> ValResult<i64> {
+    fn strict_int(&self, py: Python) -> ValResult<i64> {
+        err_val_error!(py, self, kind = ErrorKind::IntType)
+    }
+
+    fn lax_int(&self, py: Python) -> ValResult<i64> {
         match self.parse() {
             Ok(i) => Ok(i),
             Err(_) => err_val_error!(py, self, kind = ErrorKind::IntParsing),
         }
     }
 
-    fn validate_float(&self, py: Python) -> ValResult<f64> {
+    fn strict_float(&self, py: Python) -> ValResult<f64> {
+        err_val_error!(py, self, kind = ErrorKind::FloatType)
+    }
+
+    fn lax_float(&self, py: Python) -> ValResult<f64> {
         match self.parse() {
             Ok(i) => Ok(i),
             Err(_) => err_val_error!(py, self, kind = ErrorKind::FloatParsing),
         }
     }
 
-    fn validate_dict<'py>(&'py self, py: Python<'py>, _try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+    fn strict_model_check(&self, _class: &PyType) -> ValResult<bool> {
+        Ok(false)
+    }
+
+    fn strict_dict<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
         err_val_error!(py, self, kind = ErrorKind::DictType)
     }
 
-    fn validate_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
+    fn lax_dict<'py>(&'py self, py: Python<'py>, _try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+        err_val_error!(py, self, kind = ErrorKind::DictType)
+    }
+
+    fn strict_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
+        err_val_error!(py, self, kind = ErrorKind::ListType)
+    }
+
+    fn lax_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>> {
         err_val_error!(py, self, kind = ErrorKind::ListType)
     }
 }

--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -10,11 +10,8 @@ use super::shared::{int_as_bool, str_as_bool};
 use super::traits::{DictInput, Input, ListInput, ToLocItem, ToPy};
 
 impl Input for Value {
-    fn validate_none(&self, py: Python) -> ValResult<()> {
-        match self {
-            Value::Null => Ok(()),
-            _ => err_val_error!(py, self, kind = ErrorKind::NoneRequired),
-        }
+    fn is_none(&self, _py: Python) -> bool {
+        matches!(self, Value::Null)
     }
 
     fn strict_str(&self, py: Python) -> ValResult<String> {
@@ -230,8 +227,8 @@ impl ToLocItem for Value {
 
 /// Required for Dict keys so the string can behave like an Input
 impl Input for String {
-    fn validate_none(&self, py: Python) -> ValResult<()> {
-        err_val_error!(py, self, kind = ErrorKind::NoneRequired)
+    fn is_none(&self, _py: Python) -> bool {
+        false
     }
 
     fn strict_str(&self, _py: Python) -> ValResult<String> {

--- a/src/input/python.rs
+++ b/src/input/python.rs
@@ -9,10 +9,6 @@ use super::shared::{int_as_bool, str_as_bool};
 use super::traits::{DictInput, Input, ListInput, ToLocItem, ToPy};
 
 impl Input for PyAny {
-    fn is_direct_instance_of(&self, class: &PyType) -> ValResult<bool> {
-        self.get_type().eq(class).map_err(as_internal)
-    }
-
     fn validate_none(&self, py: Python) -> ValResult<()> {
         if self.is_none() {
             Ok(())
@@ -21,7 +17,15 @@ impl Input for PyAny {
         }
     }
 
-    fn validate_str(&self, py: Python) -> ValResult<String> {
+    fn strict_str(&self, py: Python) -> ValResult<String> {
+        if let Ok(py_str) = self.cast_as::<PyString>() {
+            py_str.extract().map_err(as_internal)
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::StrType)
+        }
+    }
+
+    fn lax_str(&self, py: Python) -> ValResult<String> {
         if let Ok(py_str) = self.cast_as::<PyString>() {
             py_str.extract().map_err(as_internal)
         } else if let Ok(bytes) = self.cast_as::<PyBytes>() {
@@ -41,12 +45,19 @@ impl Input for PyAny {
             // don't cast_as here so Decimals are covered - internally f64:extract uses PyFloat_AsDouble
             Ok(float.to_string())
         } else {
-            // let name = self.get_type().name().unwrap_or("<unknown type>");
             err_val_error!(py, self, kind = ErrorKind::StrType)
         }
     }
 
-    fn validate_bool(&self, py: Python) -> ValResult<bool> {
+    fn strict_bool(&self, py: Python) -> ValResult<bool> {
+        if let Ok(bool) = self.extract::<bool>() {
+            Ok(bool)
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::BoolType)
+        }
+    }
+
+    fn lax_bool(&self, py: Python) -> ValResult<bool> {
         if let Ok(bool) = self.extract::<bool>() {
             Ok(bool)
         } else if let Some(str) = _maybe_as_string(py, self, ErrorKind::BoolParsing)? {
@@ -58,7 +69,18 @@ impl Input for PyAny {
         }
     }
 
-    fn validate_int(&self, py: Python) -> ValResult<i64> {
+    fn strict_int(&self, py: Python) -> ValResult<i64> {
+        // bool check has to come before int check as bools would be cast to ints below
+        if let Ok(bool) = self.extract::<bool>() {
+            err_val_error!(py, bool, kind = ErrorKind::IntType)
+        } else if let Ok(int) = self.extract::<i64>() {
+            Ok(int)
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::IntType)
+        }
+    }
+
+    fn lax_int(&self, py: Python) -> ValResult<i64> {
         if let Ok(int) = self.extract::<i64>() {
             Ok(int)
         } else if let Some(str) = _maybe_as_string(py, self, ErrorKind::IntParsing)? {
@@ -66,7 +88,7 @@ impl Input for PyAny {
                 Ok(i) => Ok(i),
                 Err(_) => err_val_error!(py, str, kind = ErrorKind::IntParsing),
             }
-        } else if let Ok(float) = self.validate_float(py) {
+        } else if let Ok(float) = self.lax_float(py) {
             if float % 1.0 == 0.0 {
                 Ok(float as i64)
             } else {
@@ -77,7 +99,15 @@ impl Input for PyAny {
         }
     }
 
-    fn validate_float(&self, py: Python) -> ValResult<f64> {
+    fn strict_float(&self, py: Python) -> ValResult<f64> {
+        if let Ok(int) = self.extract::<f64>() {
+            Ok(int)
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::FloatType)
+        }
+    }
+
+    fn lax_float(&self, py: Python) -> ValResult<f64> {
         if let Ok(int) = self.extract::<f64>() {
             Ok(int)
         } else if let Some(str) = _maybe_as_string(py, self, ErrorKind::FloatParsing)? {
@@ -90,7 +120,19 @@ impl Input for PyAny {
         }
     }
 
-    fn validate_dict<'py>(&'py self, py: Python<'py>, try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+    fn strict_model_check(&self, class: &PyType) -> ValResult<bool> {
+        self.get_type().eq(class).map_err(as_internal)
+    }
+
+    fn strict_dict<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
+        if let Ok(dict) = self.cast_as::<PyDict>() {
+            Ok(Box::new(dict))
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::DictType)
+        }
+    }
+
+    fn lax_dict<'py>(&'py self, py: Python<'py>, try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>> {
         if let Ok(dict) = self.cast_as::<PyDict>() {
             Ok(Box::new(dict))
         } else if let Ok(mapping) = self.cast_as::<PyMapping>() {
@@ -120,13 +162,21 @@ impl Input for PyAny {
                     )
                 }
             };
-            inner_dict.validate_dict(py, false)
+            inner_dict.lax_dict(py, false)
         } else {
             err_val_error!(py, self, kind = ErrorKind::DictType)
         }
     }
 
-    fn validate_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput + 'py>> {
+    fn strict_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput + 'py>> {
+        if let Ok(list) = self.cast_as::<PyList>() {
+            Ok(Box::new(list))
+        } else {
+            err_val_error!(py, self, kind = ErrorKind::ListType)
+        }
+    }
+
+    fn lax_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput + 'py>> {
         if let Ok(list) = self.cast_as::<PyList>() {
             Ok(Box::new(list))
             // TODO support sets, tuples, frozen set etc. like in pydantic

--- a/src/input/python.rs
+++ b/src/input/python.rs
@@ -9,12 +9,8 @@ use super::shared::{int_as_bool, str_as_bool};
 use super::traits::{DictInput, Input, ListInput, ToLocItem, ToPy};
 
 impl Input for PyAny {
-    fn validate_none(&self, py: Python) -> ValResult<()> {
-        if self.is_none() {
-            Ok(())
-        } else {
-            err_val_error!(py, self, kind = ErrorKind::NoneRequired)
-        }
+    fn is_none(&self, _py: Python) -> bool {
+        self.is_none()
     }
 
     fn strict_str(&self, py: Python) -> ValResult<String> {

--- a/src/input/traits.rs
+++ b/src/input/traits.rs
@@ -62,7 +62,7 @@ impl ToLocItem for &str {
 }
 
 pub trait Input: fmt::Debug + ToPy + ToLocItem {
-    fn validate_none(&self, py: Python) -> ValResult<()>;
+    fn is_none(&self, py: Python) -> bool;
 
     fn strict_str(&self, py: Python) -> ValResult<String>;
 

--- a/src/input/traits.rs
+++ b/src/input/traits.rs
@@ -24,6 +24,13 @@ impl ToPy for &str {
     }
 }
 
+impl ToPy for bool {
+    #[inline]
+    fn to_py(&self, py: Python) -> PyObject {
+        self.into_py(py)
+    }
+}
+
 impl ToPy for i64 {
     #[inline]
     fn to_py(&self, py: Python) -> PyObject {
@@ -55,21 +62,33 @@ impl ToLocItem for &str {
 }
 
 pub trait Input: fmt::Debug + ToPy + ToLocItem {
-    fn is_direct_instance_of(&self, class: &PyType) -> ValResult<bool>;
-
     fn validate_none(&self, py: Python) -> ValResult<()>;
 
-    fn validate_str(&self, py: Python) -> ValResult<String>;
+    fn strict_str(&self, py: Python) -> ValResult<String>;
 
-    fn validate_bool(&self, py: Python) -> ValResult<bool>;
+    fn lax_str(&self, py: Python) -> ValResult<String>;
 
-    fn validate_int(&self, py: Python) -> ValResult<i64>;
+    fn strict_bool(&self, py: Python) -> ValResult<bool>;
 
-    fn validate_float(&self, py: Python) -> ValResult<f64>;
+    fn lax_bool(&self, py: Python) -> ValResult<bool>;
 
-    fn validate_dict<'py>(&'py self, py: Python<'py>, try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>>;
+    fn strict_int(&self, py: Python) -> ValResult<i64>;
 
-    fn validate_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>>;
+    fn lax_int(&self, py: Python) -> ValResult<i64>;
+
+    fn strict_float(&self, py: Python) -> ValResult<f64>;
+
+    fn lax_float(&self, py: Python) -> ValResult<f64>;
+
+    fn strict_model_check(&self, class: &PyType) -> ValResult<bool>;
+
+    fn strict_dict<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn DictInput<'py> + 'py>>;
+
+    fn lax_dict<'py>(&'py self, py: Python<'py>, try_instance: bool) -> ValResult<Box<dyn DictInput<'py> + 'py>>;
+
+    fn strict_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>>;
+
+    fn lax_list<'py>(&'py self, py: Python<'py>) -> ValResult<Box<dyn ListInput<'py> + 'py>>;
 }
 
 // these are ugly, is there any way to avoid the maps in iter, one of the boxes and/or the duplication?

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -21,7 +21,7 @@ impl Validator for BoolValidator {
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
-        Ok(input.validate_bool(py)?.into_py(py))
+        Ok(input.lax_bool(py)?.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -17,7 +17,7 @@ impl BoolValidator {
 impl Validator for BoolValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
         if is_strict!(schema, config) {
-            Ok(Box::new(StrictBoolValidator {}))
+            StrictBoolValidator::build(schema, config)
         } else {
             Ok(Box::new(Self {}))
         }
@@ -35,11 +35,11 @@ impl Validator for BoolValidator {
 }
 
 #[derive(Debug, Clone)]
-pub struct StrictBoolValidator;
+struct StrictBoolValidator;
 
 impl Validator for StrictBoolValidator {
     fn build(_schema: &PyDict, _config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
-        unimplemented!("should be built by BoolValidator")
+        Ok(Box::new(Self {}))
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::build_macros::{dict_get, optional_dict_get};
+use crate::build_macros::is_strict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
@@ -16,12 +16,7 @@ impl BoolValidator {
 
 impl Validator for BoolValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
-        let strict = match dict_get!(schema, "strict", bool) {
-            Some(v) => v,
-            None => optional_dict_get!(config, "strict", bool).unwrap_or(false),
-        };
-
-        if strict {
+        if is_strict!(schema, config) {
             Ok(Box::new(StrictBoolValidator {}))
         } else {
             Ok(Box::new(Self {}))

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -1,27 +1,39 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::build_macros::{dict_get, optional_dict_get};
 use crate::errors::ValResult;
 use crate::input::Input;
 
 use super::{Extra, Validator};
 
 #[derive(Debug, Clone)]
-pub struct BoolValidator;
+pub struct BoolValidator {
+    strict: bool,
+}
 
 impl BoolValidator {
     pub const EXPECTED_TYPE: &'static str = "bool";
 }
 
 impl Validator for BoolValidator {
-    fn build(_schema: &PyDict, _config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
-        Ok(Box::new(Self))
+    fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
+        let strict = match dict_get!(schema, "strict", bool) {
+            Some(v) => v,
+            None => optional_dict_get!(config, "strict", bool).unwrap_or(false),
+        };
+        Ok(Box::new(Self { strict }))
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
         // TODO in theory this could be quicker if we used PyBool rather than going to a bool
         // and back again, might be worth profiling?
-        Ok(input.lax_bool(py)?.into_py(py))
+        let b = if self.strict {
+            input.strict_bool(py)?
+        } else {
+            input.lax_bool(py)?
+        };
+        Ok(b.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -38,7 +38,7 @@ impl Validator for DictValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, extra: &Extra) -> ValResult<PyObject> {
-        let dict = input.validate_dict(py, self.try_instance_as_dict)?;
+        let dict = input.lax_dict(py, self.try_instance_as_dict)?;
         if let Some(min_length) = self.min_items {
             if dict.input_len() < min_length {
                 return err_val_error!(

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -9,9 +9,9 @@ use super::{build_validator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct DictValidator {
+    strict: bool,
     key_validator: Option<Box<dyn Validator>>,
     value_validator: Option<Box<dyn Validator>>,
-    strict: bool,
     min_items: Option<usize>,
     max_items: Option<usize>,
     try_instance_as_dict: bool,
@@ -24,6 +24,7 @@ impl DictValidator {
 impl Validator for DictValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
         Ok(Box::new(Self {
+            strict: is_strict!(schema, config),
             key_validator: match dict_get!(schema, "keys", &PyDict) {
                 Some(d) => Some(build_validator(d, config)?),
                 None => None,
@@ -32,7 +33,6 @@ impl Validator for DictValidator {
                 Some(d) => Some(build_validator(d, config)?),
                 None => None,
             },
-            strict: is_strict!(schema, config),
             min_items: dict_get!(schema, "min_items", usize),
             max_items: dict_get!(schema, "max_items", usize),
             try_instance_as_dict: dict_get!(schema, "try_instance_as_dict", bool).unwrap_or(false),

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -15,12 +15,33 @@ impl FloatValidator {
 }
 
 impl Validator for FloatValidator {
+    fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
+        if is_strict!(schema, config) {
+            StrictFloatValidator::build(schema, config)
+        } else {
+            Ok(Box::new(Self))
+        }
+    }
+
+    fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
+        Ok(input.lax_float(py)?.into_py(py))
+    }
+
+    fn clone_dyn(&self) -> Box<dyn Validator> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StrictFloatValidator;
+
+impl Validator for StrictFloatValidator {
     fn build(_schema: &PyDict, _config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
         Ok(Box::new(Self))
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        Ok(input.lax_float(py)?.into_py(py))
+        Ok(input.strict_float(py)?.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -20,7 +20,7 @@ impl Validator for FloatValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        Ok(input.validate_float(py)?.into_py(py))
+        Ok(input.lax_float(py)?.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {
@@ -53,7 +53,7 @@ impl Validator for FloatConstrainedValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let float = input.validate_float(py)?;
+        let float = input.lax_float(py)?;
         if let Some(multiple_of) = self.multiple_of {
             if float % multiple_of != 0.0 {
                 return err_val_error!(

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -9,6 +9,34 @@ use crate::validators::build_validator;
 
 use super::{Extra, Validator};
 
+#[derive(Debug, Clone)]
+pub struct FunctionValidator;
+
+impl FunctionValidator {
+    pub const EXPECTED_TYPE: &'static str = "function";
+}
+
+impl Validator for FunctionValidator {
+    fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
+        let mode = dict_get_required!(schema, "mode", &str)?;
+        match mode {
+            "before" => FunctionBeforeValidator::build(schema, config),
+            "after" => FunctionAfterValidator::build(schema, config),
+            "plain" => FunctionPlainValidator::build(schema, config),
+            "wrap" => FunctionWrapValidator::build(schema, config),
+            _ => py_error!("Unexpected function mode {:?}", mode),
+        }
+    }
+
+    fn validate(&self, _py: Python, _input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
+        unimplemented!("FunctionValidator is never used directly")
+    }
+
+    fn clone_dyn(&self) -> Box<dyn Validator> {
+        Box::new(self.clone())
+    }
+}
+
 macro_rules! kwargs {
     ($py:ident, $($k:expr => $v:expr),*) => {{
         Some(dict!($py, $($k => $v),*))
@@ -28,14 +56,10 @@ macro_rules! build {
 }
 
 #[derive(Debug, Clone)]
-pub struct FunctionBeforeValidator {
+struct FunctionBeforeValidator {
     validator: Box<dyn Validator>,
     func: PyObject,
     config: Option<Py<PyDict>>,
-}
-
-impl FunctionBeforeValidator {
-    pub const EXPECTED_TYPE: &'static str = "function-before";
 }
 
 impl Validator for FunctionBeforeValidator {
@@ -57,14 +81,10 @@ impl Validator for FunctionBeforeValidator {
 }
 
 #[derive(Debug, Clone)]
-pub struct FunctionAfterValidator {
+struct FunctionAfterValidator {
     validator: Box<dyn Validator>,
     func: PyObject,
     config: Option<Py<PyDict>>,
-}
-
-impl FunctionAfterValidator {
-    pub const EXPECTED_TYPE: &'static str = "function-after";
 }
 
 impl Validator for FunctionAfterValidator {
@@ -82,13 +102,9 @@ impl Validator for FunctionAfterValidator {
 }
 
 #[derive(Debug, Clone)]
-pub struct FunctionPlainValidator {
+struct FunctionPlainValidator {
     func: PyObject,
     config: Option<Py<PyDict>>,
-}
-
-impl FunctionPlainValidator {
-    pub const EXPECTED_TYPE: &'static str = "function-plain";
 }
 
 impl Validator for FunctionPlainValidator {
@@ -112,14 +128,10 @@ impl Validator for FunctionPlainValidator {
 }
 
 #[derive(Debug, Clone)]
-pub struct FunctionWrapValidator {
+struct FunctionWrapValidator {
     validator: Box<dyn Validator>,
     func: PyObject,
     config: Option<Py<PyDict>>,
-}
-
-impl FunctionWrapValidator {
-    pub const EXPECTED_TYPE: &'static str = "function-wrap";
 }
 
 impl Validator for FunctionWrapValidator {
@@ -149,7 +161,7 @@ impl Validator for FunctionWrapValidator {
 
 #[pyclass]
 #[derive(Debug, Clone)]
-pub struct ValidatorCallable {
+struct ValidatorCallable {
     validator: Box<dyn Validator>,
     data: Option<Py<PyDict>>,
     field: Option<String>,

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -20,7 +20,7 @@ impl Validator for IntValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        Ok(input.validate_int(py)?.into_py(py))
+        Ok(input.lax_int(py)?.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {
@@ -53,7 +53,7 @@ impl Validator for IntConstrainedValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let int = input.validate_int(py)?;
+        let int = input.lax_int(py)?;
         if let Some(multiple_of) = self.multiple_of {
             if int % multiple_of != 0 {
                 return err_val_error!(

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -31,7 +31,7 @@ impl Validator for ListValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, extra: &Extra) -> ValResult<PyObject> {
-        let list = input.validate_list(py)?;
+        let list = input.lax_list(py)?;
         let length = list.input_len();
         if let Some(min_length) = self.min_items {
             if length < min_length {

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::build_macros::dict_get;
+use crate::build_macros::{dict_get, is_strict};
 use crate::errors::{context, err_val_error, ErrorKind, LocItem, ValError, ValLineError};
 use crate::input::Input;
 
@@ -9,6 +9,7 @@ use super::{build_validator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ListValidator {
+    strict: bool,
     item_validator: Option<Box<dyn Validator>>,
     min_items: Option<usize>,
     max_items: Option<usize>,
@@ -21,6 +22,7 @@ impl ListValidator {
 impl Validator for ListValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
         Ok(Box::new(Self {
+            strict: is_strict!(schema, config),
             item_validator: match dict_get!(schema, "items", &PyDict) {
                 Some(d) => Some(build_validator(d, config)?),
                 None => None,
@@ -31,7 +33,10 @@ impl Validator for ListValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, extra: &Extra) -> ValResult<PyObject> {
-        let list = input.lax_list(py)?;
+        let list = match self.strict {
+            true => input.strict_list(py)?,
+            false => input.lax_list(py)?,
+        };
         let length = list.input_len();
         if let Some(min_length) = self.min_items {
             if length < min_length {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -105,28 +105,24 @@ pub fn build_validator(dict: &PyDict, config: Option<&PyDict>) -> PyResult<Box<d
         config,
         // models e.g. heterogeneous dicts
         self::model::ModelValidator,
+        // model classes
         self::model_create::ModelClassValidator,
         // strings
         self::string::StrValidator,
         // integers
         self::int::IntValidator,
-        self::int::IntConstrainedValidator,
         // boolean
         self::bool::BoolValidator,
         // floats
         self::float::FloatValidator,
-        self::float::FloatConstrainedValidator,
         // list/arrays (recursive)
         self::list::ListValidator,
         // dicts/objects (recursive)
         self::dict::DictValidator,
         // None/null
         self::none::NoneValidator,
-        // decorators
-        self::function::FunctionBeforeValidator,
-        self::function::FunctionAfterValidator,
-        self::function::FunctionPlainValidator,
-        self::function::FunctionWrapValidator,
+        // functions - before, after, plain & wrap
+        self::function::FunctionValidator,
     )
 }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -108,7 +108,6 @@ pub fn build_validator(dict: &PyDict, config: Option<&PyDict>) -> PyResult<Box<d
         self::model_create::ModelClassValidator,
         // strings
         self::string::StrValidator,
-        self::string::StrConstrainedValidator,
         // integers
         self::int::IntValidator,
         self::int::IntConstrainedValidator,

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -77,7 +77,7 @@ impl Validator for ModelValidator {
             return self.validate_assignment(py, field, input, extra);
         }
 
-        let dict = input.validate_dict(py, true)?;
+        let dict = input.lax_dict(py, true)?;
         let output_dict = PyDict::new(py);
         let mut errors: Vec<ValLineError> = Vec::new();
         let mut fields_set: HashSet<String> = HashSet::with_capacity(dict.input_len());
@@ -121,7 +121,7 @@ impl Validator for ModelValidator {
         };
         if check_extra {
             for (raw_key, value) in dict.input_iter() {
-                let key: String = match raw_key.validate_str(py) {
+                let key: String = match raw_key.lax_str(py) {
                     Ok(k) => k,
                     Err(ValError::LineErrors(line_errors)) => {
                         let loc = vec![raw_key.to_loc()?];

--- a/src/validators/model_create.rs
+++ b/src/validators/model_create.rs
@@ -41,7 +41,7 @@ impl Validator for ModelClassValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, extra: &Extra) -> ValResult<PyObject> {
-        if input.is_direct_instance_of(self.class.as_ref(py))? {
+        if input.strict_model_check(self.class.as_ref(py))? {
             Ok(input.to_py(py))
         } else {
             let output = self.validator.validate(py, input, extra)?;

--- a/src/validators/model_create.rs
+++ b/src/validators/model_create.rs
@@ -6,12 +6,13 @@ use pyo3::types::{PyDict, PyTuple, PyType};
 use pyo3::{ffi, intern, ToBorrowedObject};
 
 use super::{build_validator, Extra, ValResult, Validator};
-use crate::build_macros::{dict_get_required, py_error};
-use crate::errors::as_internal;
+use crate::build_macros::{dict_get, dict_get_required, py_error};
+use crate::errors::{as_internal, context, err_val_error, ErrorKind};
 use crate::input::Input;
 
 #[derive(Debug, Clone)]
 pub struct ModelClassValidator {
+    strict: bool,
     validator: Box<dyn Validator>,
     class: Py<PyType>,
     new_method: PyObject,
@@ -34,6 +35,9 @@ impl Validator for ModelClassValidator {
         }
 
         Ok(Box::new(Self {
+            // we don't use is_strict here since we don't wan validation to be strict in this case if
+            // `config.strict` is set, only if this specific field is strict
+            strict: dict_get!(schema, "strict", bool).unwrap_or(false),
             validator: build_validator(model_schema, config)?,
             class: class.into(),
             new_method: new_method.into(),
@@ -41,8 +45,16 @@ impl Validator for ModelClassValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, extra: &Extra) -> ValResult<PyObject> {
-        if input.strict_model_check(self.class.as_ref(py))? {
+        let class = self.class.as_ref(py);
+        if input.strict_model_check(class)? {
             Ok(input.to_py(py))
+        } else if self.strict {
+            err_val_error!(
+                py,
+                input,
+                kind = ErrorKind::ModelType,
+                context = context!("class_name" => class_name(py, class)?)
+            )
         } else {
             let output = self.validator.validate(py, input, extra)?;
             self.create_class(py, output).map_err(as_internal)
@@ -52,6 +64,13 @@ impl Validator for ModelClassValidator {
     fn clone_dyn(&self) -> Box<dyn Validator> {
         Box::new(self.clone())
     }
+}
+
+/// Get the class's `__name__`, not using `class.name()` since it uses `__qualname__` which is not what we want here
+#[inline]
+fn class_name(py: Python, class: &PyType) -> ValResult<String> {
+    let name = class.getattr(intern!(py, "__name__")).map_err(as_internal)?;
+    name.extract().map_err(as_internal)
 }
 
 impl ModelClassValidator {

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::errors::ValResult;
+use crate::errors::{err_val_error, ErrorKind, ValResult};
 use crate::input::Input;
 
 use super::{Extra, Validator};
@@ -19,8 +19,10 @@ impl Validator for NoneValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        input.validate_none(py)?;
-        ValResult::Ok(py.None())
+        match input.is_none(py) {
+            true => Ok(py.None()),
+            false => err_val_error!(py, input, kind = ErrorKind::NoneRequired),
+        }
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -17,7 +17,7 @@ impl StrValidator {
 
 impl Validator for StrValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
-        let use_con_str = schema.get_item("pattern").is_some()
+        let use_constrained = schema.get_item("pattern").is_some()
             || schema.get_item("max_length").is_some()
             || schema.get_item("min_length").is_some()
             || schema.get_item("strip_whitespace").is_some()
@@ -34,7 +34,7 @@ impl Validator for StrValidator {
                 }
                 None => false,
             };
-        if use_con_str {
+        if use_constrained {
             StrConstrainedValidator::build(schema, config)
         } else if is_strict!(schema, config) {
             StrictStrValidator::build(schema, config)

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 use regex::Regex;
 
-use crate::build_macros::{dict_get, py_error};
+use crate::build_macros::{dict_get, optional_dict_get, py_error};
 use crate::errors::{context, err_val_error, ErrorKind, ValResult};
 use crate::input::{Input, ToPy};
 
@@ -58,15 +58,6 @@ pub struct StrConstrainedValidator {
 
 impl StrConstrainedValidator {
     pub const EXPECTED_TYPE: &'static str = "str-constrained";
-}
-
-macro_rules! optional_dict_get {
-    ($optional_dict:ident, $key:expr, $type:ty) => {
-        match $optional_dict {
-            Some(d) => dict_get!(d, $key, $type),
-            None => None,
-        }
-    };
 }
 
 impl Validator for StrConstrainedValidator {

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -37,7 +37,7 @@ impl Validator for StrValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let s = input.validate_str(py)?;
+        let s = input.lax_str(py)?;
         ValResult::Ok(s.into_py(py))
     }
 
@@ -111,7 +111,7 @@ impl Validator for StrConstrainedValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let mut str = input.validate_str(py)?;
+        let mut str = input.lax_str(py)?;
         if let Some(min_length) = self.min_length {
             if str.len() < min_length {
                 // return py_error!("{} is shorter than {}", str, min_length);

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 use regex::Regex;
 
-use crate::build_macros::{dict_get, optional_dict_get, py_error};
+use crate::build_macros::{dict_get, is_strict, optional_dict_get, py_error};
 use crate::errors::{context, err_val_error, ErrorKind, ValResult};
 use crate::input::{Input, ToPy};
 
@@ -17,28 +17,34 @@ impl StrValidator {
 
 impl Validator for StrValidator {
     fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
-        let use_con_str = match config {
-            Some(config) => {
-                config.get_item("str_pattern").is_some()
-                    || config.get_item("str_max_length").is_some()
-                    || config.get_item("str_min_length").is_some()
-                    || config.get_item("str_strip_whitespace").is_some()
-                    || config.get_item("str_to_lower").is_some()
-                    || config.get_item("str_to_upper").is_some()
-            }
-            None => false,
-        };
-
+        let use_con_str = schema.get_item("pattern").is_some()
+            || schema.get_item("max_length").is_some()
+            || schema.get_item("min_length").is_some()
+            || schema.get_item("strip_whitespace").is_some()
+            || schema.get_item("to_lower").is_some()
+            || schema.get_item("to_upper").is_some()
+            || match config {
+                Some(config) => {
+                    config.get_item("str_pattern").is_some()
+                        || config.get_item("str_max_length").is_some()
+                        || config.get_item("str_min_length").is_some()
+                        || config.get_item("str_strip_whitespace").is_some()
+                        || config.get_item("str_to_lower").is_some()
+                        || config.get_item("str_to_upper").is_some()
+                }
+                None => false,
+            };
         if use_con_str {
             StrConstrainedValidator::build(schema, config)
+        } else if is_strict!(schema, config) {
+            StrictStrValidator::build(schema, config)
         } else {
             Ok(Box::new(Self))
         }
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let s = input.lax_str(py)?;
-        ValResult::Ok(s.into_py(py))
+        Ok(input.lax_str(py)?.into_py(py))
     }
 
     fn clone_dyn(&self) -> Box<dyn Validator> {
@@ -47,17 +53,31 @@ impl Validator for StrValidator {
 }
 
 #[derive(Debug, Clone)]
-pub struct StrConstrainedValidator {
+struct StrictStrValidator;
+
+impl Validator for StrictStrValidator {
+    fn build(_schema: &PyDict, _config: Option<&PyDict>) -> PyResult<Box<dyn Validator>> {
+        Ok(Box::new(Self))
+    }
+
+    fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
+        Ok(input.strict_str(py)?.into_py(py))
+    }
+
+    fn clone_dyn(&self) -> Box<dyn Validator> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StrConstrainedValidator {
+    strict: bool,
     pattern: Option<Regex>,
     max_length: Option<usize>,
     min_length: Option<usize>,
     strip_whitespace: bool,
     to_lower: bool,
     to_upper: bool,
-}
-
-impl StrConstrainedValidator {
-    pub const EXPECTED_TYPE: &'static str = "str-constrained";
 }
 
 impl Validator for StrConstrainedValidator {
@@ -92,6 +112,7 @@ impl Validator for StrConstrainedValidator {
         };
 
         Ok(Box::new(Self {
+            strict: is_strict!(schema, config),
             pattern,
             min_length,
             max_length,
@@ -102,7 +123,10 @@ impl Validator for StrConstrainedValidator {
     }
 
     fn validate(&self, py: Python, input: &dyn Input, _extra: &Extra) -> ValResult<PyObject> {
-        let mut str = input.lax_str(py)?;
+        let mut str = match self.strict {
+            true => input.strict_str(py)?,
+            false => input.lax_str(py)?,
+        };
         if let Some(min_length) = self.min_length {
             if str.len() < min_length {
                 // return py_error!("{} is shorter than {}", str, min_length);

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -20,10 +20,8 @@ def test_build_error_internal():
 def test_build_error_deep():
     msg = (
         'Error building "model" validator:\n'
-        '  SchemaError: Error building "int-constrained" validator:\n'
+        '  SchemaError: Error building "int" validator:\n'
         '  TypeError: \'str\' object cannot be interpreted as an integer'  # noqa Q003
     )
     with pytest.raises(SchemaError, match=msg):
-        SchemaValidator(
-            {'title': 'MyTestModel', 'type': 'model', 'fields': {'age': {'type': 'int-constrained', 'ge': 'not-int'}}}
-        )
+        SchemaValidator({'title': 'MyTestModel', 'type': 'model', 'fields': {'age': {'type': 'int', 'ge': 'not-int'}}})

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,11 +10,11 @@ def test_build_error_type():
 
 def test_build_error_internal():
     msg = (
-        'Error building "str-constrained" validator:\n'
+        'Error building "str" validator:\n'
         '  TypeError: \'str\' object cannot be interpreted as an integer'  # noqa Q003
     )
     with pytest.raises(SchemaError, match=msg):
-        SchemaValidator({'type': 'str-constrained', 'min_length': 'xxx', 'title': 'TestModel'})
+        SchemaValidator({'type': 'str', 'min_length': 'xxx', 'title': 'TestModel'})
 
 
 def test_build_error_deep():

--- a/tests/test_compound_types.py
+++ b/tests/test_compound_types.py
@@ -8,6 +8,8 @@ from pydantic_core import SchemaValidator, ValidationError
 def test_dict():
     v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
     assert v.validate_python({'1': 2, '3': 4}) == {1: 2, 3: 4}
+    v = SchemaValidator({'type': 'dict', 'strict': True, 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    assert v.validate_python({'1': 2, '3': 4}) == {1: 2, 3: 4}
 
 
 def test_dict_any_value():
@@ -31,6 +33,9 @@ def test_mapping():
 
     v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
     assert v.validate_python(MyMapping({'1': 2, 3: '4'})) == {1: 2, 3: 4}
+    v = SchemaValidator({'type': 'dict', 'strict': True, 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    with pytest.raises(ValidationError, match='Value must be a valid dictionary'):
+        v.validate_python(MyMapping({'1': 2, 3: '4'}))
 
 
 def test_dict_mapping():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -9,7 +9,9 @@ def test_function_before():
     def f(input_value, **kwargs):
         return input_value + ' Changed'
 
-    v = SchemaValidator({'title': 'Test', 'type': 'function-before', 'function': f, 'field': {'type': 'str'}})
+    v = SchemaValidator(
+        {'title': 'Test', 'type': 'function', 'mode': 'before', 'function': f, 'field': {'type': 'str'}}
+    )
 
     assert v.validate_python('input value') == 'input value Changed'
 
@@ -18,7 +20,9 @@ def test_function_before_raise():
     def f(input_value, **kwargs):
         raise ValueError('foobar')
 
-    v = SchemaValidator({'title': 'Test', 'type': 'function-before', 'function': f, 'field': {'type': 'str'}})
+    v = SchemaValidator(
+        {'title': 'Test', 'type': 'function', 'mode': 'before', 'function': f, 'field': {'type': 'str'}}
+    )
 
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python('input value') == 'input value Changed'
@@ -32,7 +36,7 @@ def test_function_wrap():
     def f(input_value, *, validator, **kwargs):
         return validator(input_value) + ' Changed'
 
-    v = SchemaValidator({'title': 'Test', 'type': 'function-wrap', 'function': f, 'field': {'type': 'str'}})
+    v = SchemaValidator({'title': 'Test', 'type': 'function', 'mode': 'wrap', 'function': f, 'field': {'type': 'str'}})
 
     # with pytest.raises(ValidationError) as exc_info:
     assert v.validate_python('input value') == 'input value Changed'
@@ -53,7 +57,7 @@ def test_function_after_data():
             'type': 'model',
             'fields': {
                 'field_a': {'type': 'int'},
-                'field_b': {'type': 'function-after', 'function': f, 'field': {'type': 'str'}},
+                'field_b': {'type': 'function', 'mode': 'after', 'function': f, 'field': {'type': 'str'}},
             },
         }
     )
@@ -77,7 +81,7 @@ def test_function_after_config():
         {
             'title': 'Test',
             'type': 'model',
-            'fields': {'test_field': {'type': 'function-after', 'function': f, 'field': {'type': 'str'}}},
+            'fields': {'test_field': {'type': 'function', 'mode': 'after', 'function': f, 'field': {'type': 'str'}}},
             'config': {'foo': 'bar'},
         }
     )
@@ -94,7 +98,7 @@ def test_config_no_model():
         f_kwargs = deepcopy(kwargs)
         return input_value + ' Changed'
 
-    v = SchemaValidator({'type': 'function-after', 'function': f, 'field': {'type': 'str'}, 'title': 'Test'})
+    v = SchemaValidator({'type': 'function', 'mode': 'after', 'function': f, 'field': {'type': 'str'}, 'title': 'Test'})
 
     assert v.validate_python(123) == '123 Changed'
     assert f_kwargs == {'data': None, 'config': None}
@@ -104,7 +108,7 @@ def test_function_plain():
     def f(input_value, **kwargs):
         return input_value * 2
 
-    v = SchemaValidator({'title': 'Test', 'type': 'function-plain', 'function': f})
+    v = SchemaValidator({'title': 'Test', 'type': 'function', 'mode': 'plain', 'function': f})
 
     assert v.validate_python(1) == 2
     assert v.validate_python('x') == 'xx'
@@ -117,7 +121,12 @@ def test_validate_assignment():
         return input_value
 
     v = SchemaValidator(
-        {'type': 'function-after', 'function': f, 'field': {'type': 'model', 'fields': {'field_a': {'type': 'str'}}}}
+        {
+            'type': 'function',
+            'mode': 'after',
+            'function': f,
+            'field': {'type': 'model', 'fields': {'field_a': {'type': 'str'}}},
+        }
     )
 
     m = {'field_a': 'test', 'more': 'foobar'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,9 +44,11 @@ def test_bool_error():
     )
 
 
-def test_repr():
+def test_bool_repr():
     v = SchemaValidator({'type': 'bool', 'title': 'TestModel'})
-    assert repr(v) == 'SchemaValidator(title="TestModel", validator=BoolValidator {\n    strict: false,\n})'
+    assert repr(v) == 'SchemaValidator(title="TestModel", validator=BoolValidator)'
+    v = SchemaValidator({'type': 'bool', 'strict': True, 'title': 'TestModel'})
+    assert repr(v) == 'SchemaValidator(title="TestModel", validator=StrictBoolValidator)'
 
 
 def test_str_constrained():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,7 +52,7 @@ def test_bool_repr():
 
 
 def test_str_constrained():
-    v = SchemaValidator({'type': 'str-constrained', 'max_length': 5, 'title': 'TestModel'})
+    v = SchemaValidator({'type': 'str', 'max_length': 5, 'title': 'TestModel'})
     assert v.validate_python('test') == 'test'
 
     with pytest.raises(ValidationError, match='String must have at most 5 characters'):
@@ -96,7 +96,7 @@ def test_str(input_value, output_value, error_msg):
     ],
 )
 def test_constrained_str(kwargs, input_value, output_value, error_msg):
-    v = SchemaValidator({'type': 'str-constrained', **kwargs})
+    v = SchemaValidator({'type': 'str', **kwargs})
     if error_msg:
         assert output_value is None, 'output_value should be None if error_msg is set'
 
@@ -108,14 +108,14 @@ def test_constrained_str(kwargs, input_value, output_value, error_msg):
 
 def test_invalid_regex():
     with pytest.raises(SchemaError) as exc_info:
-        SchemaValidator({'type': 'str-constrained', 'pattern': 123})
+        SchemaValidator({'type': 'str', 'pattern': 123})
     assert exc_info.value.args[0] == (
-        'Error building "str-constrained" validator:\n' "  TypeError: 'int' object cannot be converted to 'PyString'"
+        'Error building "str" validator:\n  TypeError: \'int\' object cannot be converted to \'PyString\''
     )
     with pytest.raises(SchemaError) as exc_info:
-        SchemaValidator({'type': 'str-constrained', 'pattern': '(abc'})
+        SchemaValidator({'type': 'str', 'pattern': '(abc'})
     assert exc_info.value.args[0] == (
-        'Error building "str-constrained" validator:\n'
+        'Error building "str" validator:\n'
         '  SchemaError: regex parse error:\n'
         '    (abc\n'
         '    ^\n'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,9 +23,16 @@ def test_bool(input_value, output_value):
     assert v.validate_python(input_value) == output_value
 
 
+def test_bool_strict():
+    v = SchemaValidator({'type': 'bool', 'strict': True, 'title': 'TestModel'})
+    assert v.validate_python(True) is True
+    error_message = 'Value must be a valid boolean [kind=bool_type, input_value=true, input_type=str]'
+    with pytest.raises(ValidationError, match=re.escape(error_message)):
+        v.validate_python('true')
+
+
 def test_bool_error():
     v = SchemaValidator({'type': 'bool', 'title': 'TestModel'})
-    assert repr(v) == 'SchemaValidator(title="TestModel", validator=BoolValidator)'
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python('wrong')
@@ -39,7 +46,7 @@ def test_bool_error():
 
 def test_repr():
     v = SchemaValidator({'type': 'bool', 'title': 'TestModel'})
-    assert repr(v) == 'SchemaValidator(title="TestModel", validator=BoolValidator)'
+    assert repr(v) == 'SchemaValidator(title="TestModel", validator=BoolValidator {\n    strict: false,\n})'
 
 
 def test_str_constrained():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,6 +14,27 @@ def test_simple():
     )
 
 
+def test_strict():
+    v = SchemaValidator(
+        {
+            'type': 'model',
+            'config': {'strict': True},
+            'fields': {'field_a': {'type': 'str'}, 'field_b': {'type': 'int'}},
+        }
+    )
+
+    assert v.validate_python({'field_a': 'hello', 'field_b': 12}) == (
+        {'field_a': 'hello', 'field_b': 12},
+        {'field_b', 'field_a'},
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        assert v.validate_python({'field_a': 123, 'field_b': '123'})
+    assert exc_info.value.errors() == [
+        {'kind': 'str_type', 'loc': ['field_a'], 'message': 'Value must be a valid string', 'input_value': 123},
+        {'kind': 'int_type', 'loc': ['field_b'], 'message': 'Value must be a valid integer', 'input_value': '123'},
+    ]
+
+
 def test_with_default():
     v = SchemaValidator(
         {'type': 'model', 'fields': {'field_a': {'type': 'str'}, 'field_b': {'type': 'int', 'default': 666}}}
@@ -332,3 +353,37 @@ def test_model_class_instance_subclass():
     assert m2 != m3
     assert m3.field_a == 'init_a'
     assert not hasattr(m3, 'field_b')
+
+
+def test_model_class_strict():
+    class MyModel:
+        def __init__(self):
+            self.field_a = 'init_a'
+            self.field_b = 'init_b'
+
+    v = SchemaValidator(
+        {
+            'type': 'model-class',
+            'strict': True,
+            'class': MyModel,
+            'model': {'type': 'model', 'fields': {'field_a': {'type': 'str'}, 'field_b': {'type': 'int'}}},
+        }
+    )
+    m = MyModel()
+    m2 = v.validate_python(m)
+    assert isinstance(m, MyModel)
+    assert m is m2
+    assert m.field_a == 'init_a'
+    # note that since dict validation was not run here, there has been no check this is an int
+    assert m.field_b == 'init_b'
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python({'field_a': 'test', 'field_b': 12})
+    assert exc_info.value.errors() == [
+        {
+            'kind': 'model_type',
+            'loc': [],
+            'message': 'Value must be an instance of MyModel',
+            'input_value': {'field_a': 'test', 'field_b': 12},
+            'context': {'class_name': 'MyModel'},
+        }
+    ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -143,8 +143,8 @@ def test_validate_assignment_functions():
         {
             'type': 'model',
             'fields': {
-                'field_a': {'type': 'function-after', 'function': func_a, 'field': {'type': 'str'}},
-                'field_b': {'type': 'function-after', 'function': func_b, 'field': {'type': 'int'}},
+                'field_a': {'type': 'function', 'mode': 'after', 'function': func_a, 'field': {'type': 'str'}},
+                'field_b': {'type': 'function', 'mode': 'after', 'function': func_b, 'field': {'type': 'int'}},
             },
         }
     )
@@ -279,7 +279,8 @@ def test_model_class_root_validator():
     v = SchemaValidator(
         {
             'title': 'Test',
-            'type': 'function-wrap',
+            'type': 'function',
+            'mode': 'wrap',
             'function': f,
             'field': {
                 'type': 'model-class',


### PR DESCRIPTION
strict validation, configurable via either config or on a field.

As well as allowing general strict validation, this will also be used for the first pass during union validation, see #23

:eyes: @PrettyWood 