### PR TITLE
perf: Avoid some `String` allocations

### DIFF
--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -182,7 +182,7 @@ impl ToPy for Value {
                     panic!("{:?} is not a valid number", n)
                 }
             }
-            Value::String(s) => s.clone().into_py(py),
+            Value::String(s) => s.into_py(py),
             Value::Array(v) => v.to_py(py),
             Value::Object(m) => m.to_py(py),
         }

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -200,6 +200,6 @@ impl StrConstrainedValidator {
 fn build_regex(pattern: &str) -> PyResult<Regex> {
     match Regex::new(pattern) {
         Ok(r) => Ok(r),
-        Err(e) => py_error!("{}", e.to_string()),
+        Err(e) => py_error!("{}", e),
     }
 }


### PR DESCRIPTION
This PR removes some `String` clones and `to_string` calls. In some cases, they will happen anyway down the call stack (e.g. `&str` is turned into `String` anyway inside `ToLocItem::to_loc` for `&str`), but sometimes they were doubled.

It also replaces `&vec![field_name.clone()][..]` with `&[field]`, so a temporary vector is not allocated