### PR TITLE
create_class: use safe APIs

### DIFF
--- a/src/validators/model_class.rs
+++ b/src/validators/model_class.rs
@@ -1,8 +1,6 @@
 use std::os::raw::c_int;
-use std::ptr::null_mut;
 
-use pyo3::conversion::{AsPyPointer, FromPyPointer};
-use pyo3::exceptions::PyTypeError;
+use pyo3::conversion::AsPyPointer;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple, PyType};
 use pyo3::{ffi, intern, ToBorrowedObject};


### PR DESCRIPTION
Based on your comments over in https://github.com/PyO3/pyo3/discussions/2347 I took a look at how you created class instances in Rust.

I think it's probably better to use `self.class.call0(py)`, which is equivalent to calling `self.class()` in python without arguments. Note that unlike your original code which just called `__new__`, this also will call `__init__`, so it's probably more correct?

I took a look at running benchmarks, I wasn't sure exactly which ones would be affected by tweaking this. They all looked within noise. You might want to verify this before you accept this patch.
