### PR TITLE
Fix benchmark link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ except ValidationError as e:
 ```
 
 Pydantic-core is currently around 17x faster than pydantic standard.
-See [`benchmarks/run.py`](./benchmarks/run.py) for details.
+See [`tests/test_benchmarks.py`](./tests/test_benchmarks.py) for details.
 
 This relative performance will be less impressive for small models but could be significantly move impressive
 for deeply nested models.


### PR DESCRIPTION
The README still points to the old deleted benchmarks before 68226ea3b367118e3e6a61218f8fd8f8803e1d44.