### PR TITLE
prevent segfault on recursive schema

### DIFF
--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 /// This might seem useless, but it's useful in DictValidator to avoid Option<Validator> a lot
 #[derive(Debug, Clone)]
@@ -16,7 +16,7 @@ impl BuildValidator for AnyValidator {
     fn build(
         _schema: &PyDict,
         _config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         Ok(Self.into())
     }

--- a/src/validators/any.rs
+++ b/src/validators/any.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 /// This might seem useless, but it's useful in DictValidator to avoid Option<Validator> a lot
 #[derive(Debug, Clone)]

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -5,7 +5,7 @@ use crate::build_tools::is_strict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct BoolValidator;
@@ -16,7 +16,7 @@ impl BuildValidator for BoolValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         if is_strict(schema, config)? {
             StrictBoolValidator::build()

--- a/src/validators/bool.rs
+++ b/src/validators/bool.rs
@@ -5,7 +5,7 @@ use crate::build_tools::is_strict;
 use crate::errors::ValResult;
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct BoolValidator;

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -6,7 +6,7 @@ use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, 
 use crate::input::{GenericMapping, Input, MappingLenIter, ToLocItem};
 
 use super::any::AnyValidator;
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct DictValidator {

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -6,7 +6,7 @@ use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, 
 use crate::input::{GenericMapping, Input, MappingLenIter, ToLocItem};
 
 use super::any::AnyValidator;
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct DictValidator {
@@ -24,17 +24,17 @@ impl BuildValidator for DictValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         Ok(Self {
             strict: is_strict(schema, config)?,
             key_validator: match schema.get_item("keys") {
-                Some(schema) => Box::new(build_validator(schema, config, slots_builder)?.0),
-                None => Box::new(AnyValidator::build(schema, config, slots_builder)?),
+                Some(schema) => Box::new(build_validator(schema, config, build_context)?.0),
+                None => Box::new(AnyValidator::build(schema, config, build_context)?),
             },
             value_validator: match schema.get_item("values") {
-                Some(d) => Box::new(build_validator(d, config, slots_builder)?.0),
-                None => Box::new(AnyValidator::build(schema, config, slots_builder)?),
+                Some(d) => Box::new(build_validator(d, config, build_context)?.0),
+                None => Box::new(AnyValidator::build(schema, config, build_context)?),
             },
             min_items: schema.get_as("min_items")?,
             max_items: schema.get_as("max_items")?,

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct FloatValidator;
@@ -16,7 +16,7 @@ impl BuildValidator for FloatValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let use_constrained = schema.get_item("multiple_of").is_some()
             || schema.get_item("le").is_some()

--- a/src/validators/float.rs
+++ b/src/validators/float.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct FloatValidator;

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_validation_err, val_line_error, ErrorKind, InputValue, ValError, ValLineError, ValResult};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug)]
 pub struct FunctionBuilder;
@@ -17,14 +17,14 @@ impl BuildValidator for FunctionBuilder {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let mode: &str = schema.get_as_req("mode")?;
         match mode {
-            "before" => FunctionBeforeValidator::build(schema, config, slots_builder),
-            "after" => FunctionAfterValidator::build(schema, config, slots_builder),
+            "before" => FunctionBeforeValidator::build(schema, config, build_context),
+            "after" => FunctionAfterValidator::build(schema, config, build_context),
             "plain" => FunctionPlainValidator::build(schema, config),
-            "wrap" => FunctionWrapValidator::build(schema, config, slots_builder),
+            "wrap" => FunctionWrapValidator::build(schema, config, build_context),
             _ => py_error!("Unexpected function mode {:?}", mode),
         }
     }
@@ -42,10 +42,10 @@ macro_rules! impl_build {
             pub fn build(
                 schema: &PyDict,
                 config: Option<&PyDict>,
-                slots_builder: &mut SlotsBuilder,
+                build_context: &mut BuildContext,
             ) -> PyResult<CombinedValidator> {
                 Ok(Self {
-                    validator: Box::new(build_validator(schema.get_as_req("schema")?, config, slots_builder)?.0),
+                    validator: Box::new(build_validator(schema.get_as_req("schema")?, config, build_context)?.0),
                     func: get_function(schema)?,
                     config: config.map(|c| c.into()),
                 }

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_validation_err, val_line_error, ErrorKind, InputValue, ValError, ValLineError, ValResult};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug)]
 pub struct FunctionBuilder;

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct IntValidator;
@@ -16,7 +16,7 @@ impl BuildValidator for IntValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let use_constrained = schema.get_item("multiple_of").is_some()
             || schema.get_item("le").is_some()

--- a/src/validators/int.rs
+++ b/src/validators/int.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct IntValidator;

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, LocItem, ValError, ValLineError};
 use crate::input::{GenericSequence, Input, SequenceLenIter};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, ValResult, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ListValidator {
@@ -21,12 +21,12 @@ impl BuildValidator for ListValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         Ok(Self {
             strict: is_strict(schema, config)?,
             item_validator: match schema.get_item("items") {
-                Some(d) => Some(Box::new(build_validator(d, config, slots_builder)?.0)),
+                Some(d) => Some(Box::new(build_validator(d, config, build_context)?.0)),
                 None => None,
             },
             min_items: schema.get_as("min_items")?,

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, LocItem, ValError, ValLineError};
 use crate::input::{GenericSequence, Input, SequenceLenIter};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ListValidator {

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -7,7 +7,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug)]
 pub struct LiteralBuilder;

--- a/src/validators/literal.rs
+++ b/src/validators/literal.rs
@@ -7,7 +7,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug)]
 pub struct LiteralBuilder;
@@ -18,7 +18,7 @@ impl BuildValidator for LiteralBuilder {
     fn build(
         schema: &PyDict,
         _config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let expected: &PyList = schema.get_as_req("expected")?;
         if expected.is_empty() {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -40,8 +40,8 @@ pub struct SchemaValidator {
 impl SchemaValidator {
     #[new]
     pub fn py_new(py: Python, schema: &PyAny) -> PyResult<Self> {
-        let mut slots_builder = SlotsBuilder::new();
-        let validator = match build_validator(schema, None, &mut slots_builder) {
+        let mut build_context = BuildContext::new();
+        let validator = match build_validator(schema, None, &mut build_context) {
             Ok((v, _)) => v,
             Err(err) => {
                 return Err(match err.is_instance_of::<SchemaError>(py) {
@@ -50,7 +50,7 @@ impl SchemaValidator {
                 });
             }
         };
-        let slots = slots_builder.into_slots()?;
+        let slots = build_context.into_slots()?;
         Ok(Self {
             validator,
             slots,
@@ -121,19 +121,21 @@ pub trait BuildValidator: Sized {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator>;
 }
 
 // macro to build the match statement for validator selection
 macro_rules! validator_match {
-    ($type:ident, $dict:ident, $config:ident, $slots_builder:ident, $($validator:path,)+) => {
+    ($type:ident, $dict:ident, $config:ident, $build_context:ident, $($validator:path,)+) => {
         match $type {
             $(
                 <$validator>::EXPECTED_TYPE => {
-                    let val = <$validator>::build($dict, $config, $slots_builder).map_err(|err| {
+                    $build_context.incr_check_depth()?;
+                    let val = <$validator>::build($dict, $config, $build_context).map_err(|err| {
                         crate::SchemaError::new_err(format!("Error building \"{}\" validator:\n  {}", $type, err))
                     })?;
+                    $build_context.decr_depth();
                     Ok((val, $dict))
                 },
             )+
@@ -147,7 +149,7 @@ macro_rules! validator_match {
 pub fn build_validator<'a>(
     schema: &'a PyAny,
     config: Option<&'a PyDict>,
-    slots_builder: &mut SlotsBuilder,
+    build_context: &mut BuildContext,
 ) -> PyResult<(CombinedValidator, &'a PyDict)> {
     let dict: &PyDict = match schema.cast_as() {
         Ok(s) => s,
@@ -162,7 +164,7 @@ pub fn build_validator<'a>(
         type_,
         dict,
         config,
-        slots_builder,
+        build_context,
         // models e.g. heterogeneous dicts
         self::model::ModelValidator,
         // unions
@@ -292,22 +294,38 @@ pub trait Validator: Send + Sync + Clone + Debug {
     fn get_name(&self, py: Python) -> String;
 }
 
-pub struct SlotsBuilder {
+pub struct BuildContext {
     named_slots: Vec<(Option<String>, Option<CombinedValidator>)>,
+    depth: usize,
 }
 
-impl SlotsBuilder {
+const MAX_DEPTH: usize = 100;
+
+impl BuildContext {
     pub fn new() -> Self {
         let named_slots: Vec<(Option<String>, Option<CombinedValidator>)> = Vec::new();
-        SlotsBuilder { named_slots }
+        BuildContext { named_slots, depth: 0 }
     }
 
-    pub fn add_named(&mut self, name: String, schema: &PyAny, config: Option<&PyDict>) -> PyResult<usize> {
+    pub fn add_named_slot(&mut self, name: String, schema: &PyAny, config: Option<&PyDict>) -> PyResult<usize> {
         let id = self.named_slots.len();
         self.named_slots.push((Some(name), None));
         let validator = build_validator(schema, config, self)?.0;
         self.named_slots[id] = (None, Some(validator));
         Ok(id)
+    }
+
+    pub fn incr_check_depth(&mut self) -> PyResult<()> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            py_error!("Recursive detected, depth exceeded max allowed value of {}", MAX_DEPTH)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn decr_depth(&mut self) {
+        self.depth -= 1;
     }
 
     pub fn find_id(&self, name: &str) -> PyResult<usize> {

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use enum_dispatch::enum_dispatch;
 
+use pyo3::exceptions::PyRecursionError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 use serde_json::from_str as parse_json;
@@ -318,7 +319,7 @@ impl BuildContext {
     pub fn incr_check_depth(&mut self) -> PyResult<()> {
         self.depth += 1;
         if self.depth > MAX_DEPTH {
-            py_error!("Recursive detected, depth exceeded max allowed value of {}", MAX_DEPTH)
+            py_error!(PyRecursionError; "Recursive detected, depth exceeded max allowed value of {}", MAX_DEPTH)
         } else {
             Ok(())
         }

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -7,7 +7,7 @@ use crate::errors::{
 };
 use crate::input::{Input, MappingLenIter, ToLocItem};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 struct ModelField {

--- a/src/validators/model.rs
+++ b/src/validators/model.rs
@@ -7,7 +7,7 @@ use crate::errors::{
 };
 use crate::input::{Input, MappingLenIter, ToLocItem};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 struct ModelField {
@@ -31,7 +31,7 @@ impl BuildValidator for ModelValidator {
     fn build(
         schema: &PyDict,
         _config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         // models ignore the parent config and always use the config from this model
         let config: Option<&PyDict> = schema.get_as("config")?;
@@ -39,7 +39,7 @@ impl BuildValidator for ModelValidator {
         let extra_behavior = ExtraBehavior::from_config(config)?;
         let extra_validator = match extra_behavior {
             ExtraBehavior::Allow => match schema.get_item("extra_validator") {
-                Some(v) => Some(Box::new(build_validator(v, config, slots_builder)?.0)),
+                Some(v) => Some(Box::new(build_validator(v, config, build_context)?.0)),
                 None => None,
             },
             _ => None,
@@ -62,7 +62,7 @@ impl BuildValidator for ModelValidator {
         let mut fields: Vec<ModelField> = Vec::with_capacity(fields_dict.len());
 
         for (key, value) in fields_dict.iter() {
-            let (validator, field_dict) = match build_validator(value, config, slots_builder) {
+            let (validator, field_dict) = match build_validator(value, config, build_context) {
                 Ok(v) => v,
                 Err(err) => return py_error!("Key \"{}\":\n  {}", key, err),
             };

--- a/src/validators/model_class.rs
+++ b/src/validators/model_class.rs
@@ -11,7 +11,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, ValError, ValResult};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ModelClassValidator {
@@ -26,12 +26,12 @@ impl BuildValidator for ModelClassValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let class: &PyType = schema.get_as_req("class_type")?;
 
         let model_schema_raw: &PyAny = schema.get_as_req("model")?;
-        let (validator, model_schema) = build_validator(model_schema_raw, config, slots_builder)?;
+        let (validator, model_schema) = build_validator(model_schema_raw, config, build_context)?;
         let model_type: String = model_schema.get_as_req("type")?;
         if &model_type != "model" {
             return py_error!("model-class expected a 'model' schema, got '{}'", model_type);

--- a/src/validators/model_class.rs
+++ b/src/validators/model_class.rs
@@ -11,7 +11,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, ValError, ValResult};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct ModelClassValidator {

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::{err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct NoneValidator;
@@ -15,7 +15,7 @@ impl BuildValidator for NoneValidator {
     fn build(
         _schema: &PyDict,
         _config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         Ok(Self.into())
     }

--- a/src/validators/none.rs
+++ b/src/validators/none.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::errors::{err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct NoneValidator;

--- a/src/validators/optional.rs
+++ b/src/validators/optional.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::build_tools::SchemaDict;
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, ValResult, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct OptionalValidator {
@@ -17,11 +17,11 @@ impl BuildValidator for OptionalValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let schema: &PyAny = schema.get_as_req("schema")?;
         Ok(Self {
-            validator: Box::new(build_validator(schema, config, slots_builder)?.0),
+            validator: Box::new(build_validator(schema, config, build_context)?.0),
         }
         .into())
     }

--- a/src/validators/optional.rs
+++ b/src/validators/optional.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyDict;
 use crate::build_tools::SchemaDict;
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct OptionalValidator {

--- a/src/validators/recursive.rs
+++ b/src/validators/recursive.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct RecursiveValidator {
@@ -19,11 +19,11 @@ impl BuildValidator for RecursiveValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let sub_schema: &PyAny = schema.get_as_req("schema")?;
         let name: String = schema.get_as_req("name")?;
-        let validator_id = slots_builder.add_named(name, sub_schema, config)?;
+        let validator_id = build_context.add_named_slot(name, sub_schema, config)?;
         Ok(Self { validator_id }.into())
     }
 }
@@ -56,10 +56,10 @@ impl BuildValidator for RecursiveRefValidator {
     fn build(
         schema: &PyDict,
         _config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let name: String = schema.get_as_req("name")?;
-        let validator_id = slots_builder.find_id(&name)?;
+        let validator_id = build_context.find_id(&name)?;
         Ok(Self { validator_id }.into())
     }
 }

--- a/src/validators/recursive.rs
+++ b/src/validators/recursive.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{py_error, SchemaDict};
 use crate::errors::{as_internal, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct RecursiveValidator {

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, LocItem, ValError, ValLineError};
 use crate::input::{GenericSequence, Input, SequenceLenIter};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, ValResult, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct SetValidator {
@@ -21,12 +21,14 @@ impl BuildValidator for SetValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         Ok(Self {
             strict: is_strict(schema, config)?,
             item_validator: match schema.get_item("items") {
-                Some(d) => Some(Box::new(build_validator(d, config, slots_builder)?.0)),
+                Some(d) => {
+                    Some(Box::new(build_validator(d, config, build_context)?.0))
+                },
                 None => None,
             },
             min_items: schema.get_as("min_items")?,

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -5,7 +5,7 @@ use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{as_internal, context, err_val_error, ErrorKind, InputValue, LocItem, ValError, ValLineError};
 use crate::input::{GenericSequence, Input, SequenceLenIter};
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct SetValidator {
@@ -26,9 +26,7 @@ impl BuildValidator for SetValidator {
         Ok(Self {
             strict: is_strict(schema, config)?,
             item_validator: match schema.get_item("items") {
-                Some(d) => {
-                    Some(Box::new(build_validator(d, config, build_context)?.0))
-                },
+                Some(d) => Some(Box::new(build_validator(d, config, build_context)?.0)),
                 None => None,
             },
             min_items: schema.get_as("min_items")?,

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{is_strict, py_error, schema_or_config};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
+use super::{BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
 #[derive(Debug, Clone)]
 pub struct StrValidator;

--- a/src/validators/string.rs
+++ b/src/validators/string.rs
@@ -6,7 +6,7 @@ use crate::build_tools::{is_strict, py_error, schema_or_config};
 use crate::errors::{context, err_val_error, ErrorKind, InputValue, ValResult};
 use crate::input::Input;
 
-use super::{BuildValidator, CombinedValidator, Extra, SlotsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, Extra, BuildContext, Validator};
 
 #[derive(Debug, Clone)]
 pub struct StrValidator;
@@ -17,7 +17,7 @@ impl BuildValidator for StrValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        _slots_builder: &mut SlotsBuilder,
+        _build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let use_constrained = schema.get_item("pattern").is_some()
             || schema.get_item("max_length").is_some()

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -5,7 +5,7 @@ use crate::build_tools::SchemaDict;
 use crate::errors::{LocItem, ValError, ValLineError};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, SlotsBuilder, ValResult, Validator};
+use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct UnionValidator {
@@ -18,12 +18,12 @@ impl BuildValidator for UnionValidator {
     fn build(
         schema: &PyDict,
         config: Option<&PyDict>,
-        slots_builder: &mut SlotsBuilder,
+        build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let choices: Vec<CombinedValidator> = schema
             .get_as_req::<&PyList>("choices")?
             .iter()
-            .map(|choice| build_validator(choice, config, slots_builder).map(|result| result.0))
+            .map(|choice| build_validator(choice, config, build_context).map(|result| result.0))
             .collect::<PyResult<Vec<CombinedValidator>>>()?;
         Ok(Self { choices }.into())
     }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -5,7 +5,7 @@ use crate::build_tools::SchemaDict;
 use crate::errors::{LocItem, ValError, ValLineError};
 use crate::input::Input;
 
-use super::{build_validator, BuildValidator, CombinedValidator, Extra, BuildContext, ValResult, Validator};
+use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
 pub struct UnionValidator {

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -56,7 +56,9 @@ def test_pickle(pickle_protocol: int) -> None:
 def test_schema_recursive_error():
     schema = {'type': 'union', 'choices': []}
     schema['choices'].append(schema)
-    with pytest.raises(SchemaError, match='Recursive detected, depth exceeded max allowed value of 100'):
+    with pytest.raises(
+        SchemaError, match='RecursionError: Recursive detected, depth exceeded max allowed value of 100'
+    ):
         SchemaValidator(schema)
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -51,3 +51,16 @@ def test_pickle(pickle_protocol: int) -> None:
     v2 = pickle.loads(p)
     assert v2.validate_python('tRuE') is True
     assert repr(v1) == repr(v2)
+
+
+def test_schema_recursive_error():
+    schema = {'type': 'union', 'choices': []}
+    schema['choices'].append(schema)
+    with pytest.raises(SchemaError, match='Recursive detected, depth exceeded max allowed value of 100'):
+        SchemaValidator(schema)
+
+
+def test_not_schema_recursive_error():
+    schema = {'type': 'model', 'fields': {f'f_{i}': {'type': 'optional', 'schema': 'int'} for i in range(101)}}
+    v = SchemaValidator(schema)
+    assert repr(v).count('ModelField') == 101


### PR DESCRIPTION
fix #62

The error message is long and ugly, but technically it's correct and a lot better than a seg fault.

The other approach of tracking `id(obj)` didn't work since it was hard to detect if something was inside something else.