### PR TITLE
build: force usage of nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
 
     - name: install rust
       uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
 
     - id: cache-rust
       name: cache rust
@@ -92,11 +88,6 @@ jobs:
 
     - name: install rust
       uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-        components: rustfmt, clippy
 
     - name: cache rust
       uses: Swatinem/rust-cache@v1
@@ -136,10 +127,6 @@ jobs:
 
     - name: install rust
       uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
 
     - name: cache rust
       uses: Swatinem/rust-cache@v1
@@ -220,7 +207,6 @@ jobs:
       - name: build wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: nightly
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           container: ${{ matrix.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: install rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        profile: minimal
 
     - id: cache-rust
       name: cache rust
@@ -87,7 +89,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: install rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        profile: minimal
+        override: true
+        components: rustfmt, clippy
 
     - name: cache rust
       uses: Swatinem/rust-cache@v1
@@ -126,7 +132,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: install rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        profile: minimal
 
     - name: cache rust
       uses: Swatinem/rust-cache@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode/
 /env/
 /env*/
+.python-version
 *.py[cod]
 *.egg-info/
 build/

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
 channel = "nightly"
+components = [ "rustfmt", "clippy" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly"
-components = [ "rustfmt", "clippy" ]
-profile = "minimal"


### PR DESCRIPTION
I just tried to install everything with `make build-dev` and `make install` but I was on stable by default.
Instead of switching manually, I reckon it's better that the projects sets the needed toolchain.
IMO, the `rust-toolchain.toml` file is the best solution since it's used by both `cargo` and `maturin`