### PR TITLE
refactor: rename optional into nullable

### DIFF
--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -96,8 +96,8 @@ class NoneSchema(TypedDict):
     type: Literal['none']
 
 
-class OptionalSchema(TypedDict):
-    type: Literal['optional']
+class NullableSchema(TypedDict):
+    type: Literal['nullable']
     schema: Schema
     strict: NotRequired[bool]
 
@@ -204,7 +204,7 @@ BareType = Literal[
     'model',
     'model-class',
     'none',
-    'optional',
+    'nullable',
     'recursive-container',
     'recursive-reference',
     'set',
@@ -228,7 +228,7 @@ Schema = Union[
     ModelSchema,
     ModelClassSchema,
     NoneSchema,
-    OptionalSchema,
+    NullableSchema,
     RecursiveContainerSchema,
     RecursiveReferenceSchema,
     SetSchema,

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -26,7 +26,7 @@ mod literal;
 mod model;
 mod model_class;
 mod none;
-mod optional;
+mod nullable;
 mod recursive;
 mod set;
 mod string;
@@ -175,8 +175,8 @@ pub fn build_validator<'a>(
         model::ModelValidator,
         // unions
         union::UnionValidator,
-        // optional e.g. nullable
-        optional::OptionalValidator,
+        // nullables
+        nullable::NullableValidator,
         // model classes
         model_class::ModelClassValidator,
         // strings
@@ -236,8 +236,8 @@ pub enum CombinedValidator {
     Model(model::ModelValidator),
     // unions
     Union(union::UnionValidator),
-    // optional e.g. nullable
-    Optional(optional::OptionalValidator),
+    // nullables
+    Nullable(nullable::NullableValidator),
     // model classes
     ModelClass(model_class::ModelClassValidator),
     // strings

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -7,12 +7,12 @@ use crate::input::Input;
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, ValResult, Validator};
 
 #[derive(Debug, Clone)]
-pub struct OptionalValidator {
+pub struct NullableValidator {
     validator: Box<CombinedValidator>,
 }
 
-impl BuildValidator for OptionalValidator {
-    const EXPECTED_TYPE: &'static str = "optional";
+impl BuildValidator for NullableValidator {
+    const EXPECTED_TYPE: &'static str = "nullable";
 
     fn build(
         schema: &PyDict,
@@ -27,7 +27,7 @@ impl BuildValidator for OptionalValidator {
     }
 }
 
-impl Validator for OptionalValidator {
+impl Validator for NullableValidator {
     fn validate<'s, 'data>(
         &'s self,
         py: Python<'data>,

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -188,7 +188,7 @@ def test_recursive_model_core(recursive_model_data, benchmark):
                     'fields': {
                         'width': {'type': 'int'},
                         'branch': {
-                            'type': 'optional',
+                            'type': 'nullable',
                             'default': None,
                             'schema': {'type': 'recursive-ref', 'name': 'Branch'},
                         },
@@ -421,23 +421,23 @@ def test_many_models_core_model(benchmark):
     benchmark(v.validate_python, many_models_data)
 
 
-list_of_optional_data = [None if i % 2 else i for i in range(1000)]
+list_of_nullable_data = [None if i % 2 else i for i in range(1000)]
 
 
 @skip_pydantic
-@pytest.mark.benchmark(group='list of optional')
-def test_list_of_optional_pyd(benchmark):
+@pytest.mark.benchmark(group='list of nullable')
+def test_list_of_nullable_pyd(benchmark):
     class PydanticModel(BaseModel):
         __root__: List[Optional[int]]
 
-    benchmark(PydanticModel.parse_obj, list_of_optional_data)
+    benchmark(PydanticModel.parse_obj, list_of_nullable_data)
 
 
-@pytest.mark.benchmark(group='list of optional')
-def test_list_of_optional_core(benchmark):
-    v = SchemaValidator({'type': 'list', 'items': {'type': 'optional', 'schema': 'int'}})
+@pytest.mark.benchmark(group='list of nullable')
+def test_list_of_nullable_core(benchmark):
+    v = SchemaValidator({'type': 'list', 'items': {'type': 'nullable', 'schema': 'int'}})
 
-    benchmark(v.validate_python, list_of_optional_data)
+    benchmark(v.validate_python, list_of_nullable_data)
 
 
 some_bytes = b'0' * 1000

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -63,6 +63,6 @@ def test_schema_recursive_error():
 
 
 def test_not_schema_recursive_error():
-    schema = {'type': 'model', 'fields': {f'f_{i}': {'type': 'optional', 'schema': 'int'} for i in range(101)}}
+    schema = {'type': 'model', 'fields': {f'f_{i}': {'type': 'nullable', 'schema': 'int'} for i in range(101)}}
     v = SchemaValidator(schema)
     assert repr(v).count('ModelField') == 101

--- a/tests/validators/test_nullable.py
+++ b/tests/validators/test_nullable.py
@@ -3,8 +3,8 @@ import pytest
 from pydantic_core import SchemaValidator, ValidationError
 
 
-def test_optional():
-    v = SchemaValidator({'type': 'optional', 'schema': {'type': 'int'}})
+def test_nullable():
+    v = SchemaValidator({'type': 'nullable', 'schema': {'type': 'int'}})
     assert v.validate_python(None) is None
     assert v.validate_python(1) == 1
     assert v.validate_python('123') == 123
@@ -20,13 +20,13 @@ def test_optional():
     ]
 
 
-def test_union_optional_bool_int():
+def test_union_nullable_bool_int():
     v = SchemaValidator(
         {
             'type': 'union',
             'choices': [
-                {'type': 'optional', 'schema': {'type': 'bool'}},
-                {'type': 'optional', 'schema': {'type': 'int'}},
+                {'type': 'nullable', 'schema': {'type': 'bool'}},
+                {'type': 'nullable', 'schema': {'type': 'int'}},
             ],
         }
     )

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic_core import SchemaError, SchemaValidator, ValidationError
 
 
-def test_branch_optional():
+def test_branch_nullable():
     v = SchemaValidator(
         {
             'type': 'recursive-container',
@@ -42,7 +42,7 @@ def test_branch_optional():
     )
 
 
-def test_optional_error():
+def test_nullable_error():
     v = SchemaValidator(
         {
             'type': 'recursive-container',
@@ -224,7 +224,7 @@ def test_invalid_schema():
                     'fields': {
                         'width': {'type': 'int'},
                         'branch': {
-                            'type': 'optional',
+                            'type': 'nullable',
                             'default': None,
                             'schema': {'type': 'recursive-ref', 'name': 'Branch'},
                         },

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -152,7 +152,7 @@ class TestModelClassSimilar:
         assert m2.c == 2.0
 
 
-def test_optional_via_union():
+def test_nullable_via_union():
     v = SchemaValidator({'type': 'union', 'choices': [{'type': 'none'}, {'type': 'int'}]})
     assert v.validate_python(None) is None
     assert v.validate_python(1) == 1


### PR DESCRIPTION
This is just a proposition. Feel free to close it if you are not convinced!

IMO if we want to add https://github.com/samuelcolvin/pydantic-core/issues/69 (the issue I wanted to have a look at in the first place 😄), I reckon it's better to avoid any confusion and go directly with `nullable` and `required` instead of `optional`