### PR TITLE
Allow fields to be optional i.e. not required

### DIFF
--- a/tests/validators/test_model.py
+++ b/tests/validators/test_model.py
@@ -230,3 +230,19 @@ def test_json_error():
             'input_value': 'wrong',
         }
     ]
+
+
+def test_not_required_fields_default():
+    v = SchemaValidator(
+        {'type': 'model', 'fields': {'x': {'type': 'str'}, 'y': {'type': 'str', 'strict': True, 'required': False}}}
+    )
+
+    assert v.validate_python({'x': 'pika', 'y': 'chu'}) == ({'x': 'pika', 'y': 'chu'}, {'x', 'y'})
+    assert v.validate_python({'x': 'pika'}) == ({'x': 'pika'}, {'x'})
+
+    with pytest.raises(ValidationError) as exc_info:
+        assert v.validate_python({'x': 'pika', 'y': 123})
+
+    assert exc_info.value.errors() == [
+        {'kind': 'str_type', 'loc': ['y'], 'message': 'Value must be a valid string', 'input_value': 123}
+    ]


### PR DESCRIPTION
Proposition for #69

Easy PR to simply add an optional `required` parameter to fields. The default value is `required = True`.
A model can have be declared as  `partial` via the `config` in which case the fields are all optional by default (i.e. `required = False`)