### PR TITLE
perf: support strict union

### DIFF
--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -37,6 +37,7 @@ class DictSchema(TypedDict, total=False):
     values: Schema  # default: AnySchema
     min_items: int
     max_items: int
+    strict: bool
 
 
 class FloatSchema(TypedDict, total=False):
@@ -73,6 +74,7 @@ class ListSchema(TypedDict, total=False):
     items: Schema  # default: AnySchema
     min_items: int
     max_items: int
+    strict: bool
 
 
 class LiteralSchema(TypedDict):
@@ -128,7 +130,7 @@ class SetSchema(TypedDict, total=False):
     items: Schema
     min_items: int
     max_items: int
-    strict: int
+    strict: bool
 
 
 class FrozenSetSchema(TypedDict, total=False):
@@ -136,7 +138,7 @@ class FrozenSetSchema(TypedDict, total=False):
     items: Schema
     min_items: int
     max_items: int
-    strict: int
+    strict: bool
 
 
 class StringSchema(TypedDict, total=False):

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -238,6 +238,7 @@ pub enum CombinedValidator {
     Model(model::ModelValidator),
     // unions
     Union(union::UnionValidator),
+    StrictUnion(union::StrictUnionValidator),
     // nullables
     Nullable(nullable::NullableValidator),
     // model classes

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -238,7 +238,6 @@ pub enum CombinedValidator {
     Model(model::ModelValidator),
     // unions
     Union(union::UnionValidator),
-    StrictUnion(union::StrictUnionValidator),
     // nullables
     Nullable(nullable::NullableValidator),
     // model classes

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -10,6 +10,7 @@ use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Ex
 #[derive(Debug, Clone)]
 pub struct UnionValidator {
     choices: Vec<CombinedValidator>,
+    strict: bool,
 }
 
 impl BuildValidator for UnionValidator {
@@ -25,12 +26,8 @@ impl BuildValidator for UnionValidator {
             .iter()
             .map(|choice| build_validator(choice, config, build_context).map(|result| result.0))
             .collect::<PyResult<Vec<CombinedValidator>>>()?;
-
-        if is_strict(schema, config)? {
-            Ok(StrictUnionValidator { choices }.into())
-        } else {
-            Ok(Self { choices }.into())
-        }
+        let strict = is_strict(schema, config)?;
+        Ok(Self { choices, strict }.into())
     }
 }
 
@@ -42,72 +39,55 @@ impl Validator for UnionValidator {
         extra: &Extra,
         slots: &'data [CombinedValidator],
     ) -> ValResult<'data, PyObject> {
-        // 1st pass: check if the value is an exact instance of one of the Union types
-        if let Some(res) = self
-            .choices
-            .iter()
-            .map(|validator| validator.validate_strict(py, input, extra, slots))
-            .find(ValResult::is_ok)
-        {
-            return res;
+        if self.strict {
+            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+            for validator in &self.choices {
+                let line_errors = match validator.validate_strict(py, input, extra, slots) {
+                    Err(ValError::LineErrors(line_errors)) => line_errors,
+                    otherwise => return otherwise,
+                };
+
+                errors.extend(
+                    line_errors
+                        .into_iter()
+                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+                );
+            }
+
+            Err(ValError::LineErrors(errors))
+        } else {
+            // 1st pass: check if the value is an exact instance of one of the Union types
+            if let Some(res) = self
+                .choices
+                .iter()
+                .map(|validator| validator.validate_strict(py, input, extra, slots))
+                .find(ValResult::is_ok)
+            {
+                return res;
+            }
+
+            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+            // 2nd pass: check if the value can be coerced into one of the Union types
+            for validator in &self.choices {
+                let line_errors = match validator.validate(py, input, extra, slots) {
+                    Err(ValError::LineErrors(line_errors)) => line_errors,
+                    otherwise => return otherwise,
+                };
+
+                errors.extend(
+                    line_errors
+                        .into_iter()
+                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+                );
+            }
+
+            Err(ValError::LineErrors(errors))
         }
-
-        let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
-
-        // 2nd pass: check if the value can be coerced into one of the Union types
-        for validator in &self.choices {
-            let line_errors = match validator.validate(py, input, extra, slots) {
-                Err(ValError::LineErrors(line_errors)) => line_errors,
-                otherwise => return otherwise,
-            };
-
-            errors.extend(
-                line_errors
-                    .into_iter()
-                    .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
-            );
-        }
-
-        Err(ValError::LineErrors(errors))
     }
 
     fn get_name(&self, _py: Python) -> String {
         Self::EXPECTED_TYPE.to_string()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct StrictUnionValidator {
-    choices: Vec<CombinedValidator>,
-}
-
-impl Validator for StrictUnionValidator {
-    fn validate<'s, 'data>(
-        &'s self,
-        py: Python<'data>,
-        input: &'data impl Input<'data>,
-        extra: &Extra,
-        slots: &'data [CombinedValidator],
-    ) -> ValResult<'data, PyObject> {
-        let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
-
-        for validator in &self.choices {
-            let line_errors = match validator.validate_strict(py, input, extra, slots) {
-                Err(ValError::LineErrors(line_errors)) => line_errors,
-                otherwise => return otherwise,
-            };
-
-            errors.extend(
-                line_errors
-                    .into_iter()
-                    .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
-            );
-        }
-
-        Err(ValError::LineErrors(errors))
-    }
-
-    fn get_name(&self, _py: Python) -> String {
-        "strict-union".to_string()
     }
 }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-use crate::build_tools::SchemaDict;
+use crate::build_tools::{is_strict, SchemaDict};
 use crate::errors::{LocItem, ValError, ValLineError};
 use crate::input::Input;
 
@@ -10,6 +10,7 @@ use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Ex
 #[derive(Debug, Clone)]
 pub struct UnionValidator {
     choices: Vec<CombinedValidator>,
+    strict: bool,
 }
 
 impl BuildValidator for UnionValidator {
@@ -25,7 +26,8 @@ impl BuildValidator for UnionValidator {
             .iter()
             .map(|choice| build_validator(choice, config, build_context).map(|result| result.0))
             .collect::<PyResult<Vec<CombinedValidator>>>()?;
-        Ok(Self { choices }.into())
+        let strict = is_strict(schema, config)?;
+        Ok(Self { choices, strict }.into())
     }
 }
 
@@ -37,33 +39,52 @@ impl Validator for UnionValidator {
         extra: &Extra,
         slots: &'data [CombinedValidator],
     ) -> ValResult<'data, PyObject> {
-        // 1st pass: check if the value is an exact instance of one of the Union types
-        if let Some(res) = self
-            .choices
-            .iter()
-            .map(|validator| validator.validate_strict(py, input, extra, slots))
-            .find(ValResult::is_ok)
-        {
-            return res;
+        if self.strict {
+            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+            for validator in &self.choices {
+                let line_errors = match validator.validate_strict(py, input, extra, slots) {
+                    Err(ValError::LineErrors(line_errors)) => line_errors,
+                    otherwise => return otherwise,
+                };
+
+                errors.extend(
+                    line_errors
+                        .into_iter()
+                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+                );
+            }
+
+            Err(ValError::LineErrors(errors))
+        } else {
+            // 1st pass: check if the value is an exact instance of one of the Union types
+            if let Some(res) = self
+                .choices
+                .iter()
+                .map(|validator| validator.validate_strict(py, input, extra, slots))
+                .find(ValResult::is_ok)
+            {
+                return res;
+            }
+
+            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+            // 2nd pass: check if the value can be coerced into one of the Union types
+            for validator in &self.choices {
+                let line_errors = match validator.validate(py, input, extra, slots) {
+                    Err(ValError::LineErrors(line_errors)) => line_errors,
+                    otherwise => return otherwise,
+                };
+
+                errors.extend(
+                    line_errors
+                        .into_iter()
+                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+                );
+            }
+
+            Err(ValError::LineErrors(errors))
         }
-
-        let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
-
-        // 3rd pass: check if the value can be coerced into one of the Union types
-        for validator in &self.choices {
-            let line_errors = match validator.validate(py, input, extra, slots) {
-                Err(ValError::LineErrors(line_errors)) => line_errors,
-                otherwise => return otherwise,
-            };
-
-            errors.extend(
-                line_errors
-                    .into_iter()
-                    .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
-            );
-        }
-
-        Err(ValError::LineErrors(errors))
     }
 
     fn get_name(&self, _py: Python) -> String {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -10,7 +10,6 @@ use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Ex
 #[derive(Debug, Clone)]
 pub struct UnionValidator {
     choices: Vec<CombinedValidator>,
-    strict: bool,
 }
 
 impl BuildValidator for UnionValidator {
@@ -26,8 +25,12 @@ impl BuildValidator for UnionValidator {
             .iter()
             .map(|choice| build_validator(choice, config, build_context).map(|result| result.0))
             .collect::<PyResult<Vec<CombinedValidator>>>()?;
-        let strict = is_strict(schema, config)?;
-        Ok(Self { choices, strict }.into())
+
+        if is_strict(schema, config)? {
+            Ok(StrictUnionValidator { choices }.into())
+        } else {
+            Ok(Self { choices }.into())
+        }
     }
 }
 
@@ -39,55 +42,72 @@ impl Validator for UnionValidator {
         extra: &Extra,
         slots: &'data [CombinedValidator],
     ) -> ValResult<'data, PyObject> {
-        if self.strict {
-            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
-
-            for validator in &self.choices {
-                let line_errors = match validator.validate_strict(py, input, extra, slots) {
-                    Err(ValError::LineErrors(line_errors)) => line_errors,
-                    otherwise => return otherwise,
-                };
-
-                errors.extend(
-                    line_errors
-                        .into_iter()
-                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
-                );
-            }
-
-            Err(ValError::LineErrors(errors))
-        } else {
-            // 1st pass: check if the value is an exact instance of one of the Union types
-            if let Some(res) = self
-                .choices
-                .iter()
-                .map(|validator| validator.validate_strict(py, input, extra, slots))
-                .find(ValResult::is_ok)
-            {
-                return res;
-            }
-
-            let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
-
-            // 2nd pass: check if the value can be coerced into one of the Union types
-            for validator in &self.choices {
-                let line_errors = match validator.validate(py, input, extra, slots) {
-                    Err(ValError::LineErrors(line_errors)) => line_errors,
-                    otherwise => return otherwise,
-                };
-
-                errors.extend(
-                    line_errors
-                        .into_iter()
-                        .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
-                );
-            }
-
-            Err(ValError::LineErrors(errors))
+        // 1st pass: check if the value is an exact instance of one of the Union types
+        if let Some(res) = self
+            .choices
+            .iter()
+            .map(|validator| validator.validate_strict(py, input, extra, slots))
+            .find(ValResult::is_ok)
+        {
+            return res;
         }
+
+        let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+        // 2nd pass: check if the value can be coerced into one of the Union types
+        for validator in &self.choices {
+            let line_errors = match validator.validate(py, input, extra, slots) {
+                Err(ValError::LineErrors(line_errors)) => line_errors,
+                otherwise => return otherwise,
+            };
+
+            errors.extend(
+                line_errors
+                    .into_iter()
+                    .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+            );
+        }
+
+        Err(ValError::LineErrors(errors))
     }
 
     fn get_name(&self, _py: Python) -> String {
         Self::EXPECTED_TYPE.to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StrictUnionValidator {
+    choices: Vec<CombinedValidator>,
+}
+
+impl Validator for StrictUnionValidator {
+    fn validate<'s, 'data>(
+        &'s self,
+        py: Python<'data>,
+        input: &'data impl Input<'data>,
+        extra: &Extra,
+        slots: &'data [CombinedValidator],
+    ) -> ValResult<'data, PyObject> {
+        let mut errors: Vec<ValLineError> = Vec::with_capacity(self.choices.len());
+
+        for validator in &self.choices {
+            let line_errors = match validator.validate_strict(py, input, extra, slots) {
+                Err(ValError::LineErrors(line_errors)) => line_errors,
+                otherwise => return otherwise,
+            };
+
+            errors.extend(
+                line_errors
+                    .into_iter()
+                    .map(|err| err.with_prefix_location(LocItem::S(validator.get_name(py)))),
+            );
+        }
+
+        Err(ValError::LineErrors(errors))
+    }
+
+    fn get_name(&self, _py: Python) -> String {
+        "strict-union".to_string()
     }
 }

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -215,3 +215,17 @@ def test_no_choices():
         SchemaValidator({'type': 'union'})
 
     assert exc_info.value.args[0] == ('Error building "union" validator:\n' '  KeyError: \'"choices" is required\'')
+
+
+def test_strict_union():
+    v = SchemaValidator({'type': 'union', 'strict': True, 'choices': [{'type': 'bool'}, {'type': 'int'}]})
+    assert v.validate_python(1) == 1
+    assert v.validate_python(123) == 123
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python('123') == 123
+
+    assert exc_info.value.errors() == [
+        {'kind': 'bool_type', 'loc': ['bool'], 'message': 'Value must be a valid boolean', 'input_value': '123'},
+        {'kind': 'int_type', 'loc': ['int'], 'message': 'Value must be a valid integer', 'input_value': '123'},
+    ]


### PR DESCRIPTION
```
main branch
———
[1_000_000 times] lax union with 5 choices: 2.89s
[1_000_000 times] strict union with 5 choices: 2.84s

strict-union branch
——————
[1_000_000 times] lax union with 5 choices: 2.84s
[1_000_000 times] strict union with 5 choices: 1.84s
```

<details>
  <summary>Run script</summary>
  
```py
import time
from pydantic_core import SchemaValidator, ValidationError


for strict in (False, True):
    v = SchemaValidator({
        'type': 'model',
        'config': {'strict': strict},
        'fields': {
            'x': {
                'schema': {
                    'type': 'union',
                    'choices': [{'type': 'bool'}, {'type': 'int'}, {'type': 'str'}, {'type': 'float'}, {'type': 'date'}],
                }
            }
        }
    })
    start = time.time()
    for _ in range(1_000_000):
        try:
            v.validate_python({'x': [0]})
        except ValidationError as e:
            pass
        else:
            raise
    print(f"[1_000_000 times] {'strict' if strict else 'lax'} union with 5 choices: {time.time() - start:.2f}s")
```
</details>