### PR TITLE
Support build on stable Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,21 @@ on:
 
 jobs:
   test:
-    name: test py${{ matrix.python-version }}
+    name: test py${{ matrix.python-version }} rust ${{ matrix.rust-toolchain }}
     strategy:
       fail-fast: false
       matrix:
+        rust-toolchain:
+          - nightly
         python-version:
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11.0-alpha - 3.11'
+        include:
+          - rust-toolchain: stable
+            python-version: '3.10'
 
     runs-on: ubuntu-latest
 
@@ -33,6 +38,8 @@ jobs:
       uses: actions-rs/toolchain@v1.0.6
       with:
         profile: minimal
+        toolchain: ${{ matrix.rust-toolchain }}
+        override: true
 
     - id: cache-rust
       name: cache rust
@@ -215,7 +222,6 @@ jobs:
       - name: build wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: nightly
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           container: ${{ matrix.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
     - run: ./tests/rust_coverage_export.sh
 
     - uses: codecov/codecov-action@v2
+      if: matrix.rust-toolchain == 'nightly'
       with:
         env_vars: PYTHON
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "speedate",
  "strum",
  "strum_macros",
+ "version_check",
 ]
 
 [[package]]
@@ -385,6 +386,12 @@ name = "unindent"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ name = "pydantic_core._pydantic_core"
 [profile.release]
 lto = "fat"
 codegen-units = 1
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if let Some(true) = version_check::supports_feature("no_coverage") {
+        println!("cargo:rustc-cfg=has_no_coverage");
+    }
+}

--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -195,7 +195,7 @@ impl<'a> Input<'a> for String {
         InputValue::String(self)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn is_none(&self) -> bool {
         false
     }
@@ -204,7 +204,7 @@ impl<'a> Input<'a> for String {
         Ok(self.clone().into())
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_bool(&self) -> ValResult<bool> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::BoolType)
     }
@@ -213,12 +213,12 @@ impl<'a> Input<'a> for String {
         str_as_bool(self, self)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_int(&self) -> ValResult<i64> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::IntType)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn lax_int(&self) -> ValResult<i64> {
         match self.parse() {
             Ok(i) => Ok(i),
@@ -226,12 +226,12 @@ impl<'a> Input<'a> for String {
         }
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_float(&self) -> ValResult<f64> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::FloatType)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn lax_float(&self) -> ValResult<f64> {
         match self.parse() {
             Ok(i) => Ok(i),
@@ -239,27 +239,27 @@ impl<'a> Input<'a> for String {
         }
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_model_check(&self, _class: &PyType) -> ValResult<bool> {
         Ok(false)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_dict<'data>(&'data self) -> ValResult<GenericMapping<'data>> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::DictType)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_list<'data>(&'data self) -> ValResult<GenericSequence<'data>> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::ListType)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_set<'data>(&'data self) -> ValResult<GenericSequence<'data>> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::SetType)
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_frozenset<'data>(&'data self) -> ValResult<GenericSequence<'data>> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::FrozenSetType)
     }
@@ -280,7 +280,7 @@ impl<'a> Input<'a> for String {
         bytes_as_datetime(self, self.as_bytes())
     }
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn strict_tuple<'data>(&'data self) -> ValResult<GenericSequence<'data>> {
         err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::TupleType)
     }

--- a/src/input/parse_json.rs
+++ b/src/input/parse_json.rs
@@ -62,7 +62,7 @@ impl<'de> Deserialize<'de> for JsonInput {
         impl<'de> Visitor<'de> for JsonVisitor {
             type Value = JsonInput;
 
-            #[no_coverage]
+            #[cfg_attr(has_no_coverage, no_coverage)]
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("any valid JSON value")
             }
@@ -171,7 +171,7 @@ impl<'de> DeserializeSeed<'de> for KeyDeserializer {
 impl<'de> Visitor<'de> for KeyDeserializer {
     type Value = String;
 
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a string key")
     }

--- a/src/input/to_loc_item.rs
+++ b/src/input/to_loc_item.rs
@@ -27,7 +27,7 @@ impl ToLocItem for usize {
 
 /// This is required by since JSON object keys are always strings, I don't think it can be called
 impl ToLocItem for JsonInput {
-    #[no_coverage]
+    #[cfg_attr(has_no_coverage, no_coverage)]
     fn to_loc(&self) -> LocItem {
         match self {
             JsonInput::Int(i) => LocItem::I(*i as usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(no_coverage)]
+#![cfg_attr(has_no_coverage, feature(no_coverage))]
 #![allow(clippy::borrow_deref_ref)]
 
 use pyo3::create_exception;


### PR DESCRIPTION
The only unstable feature used in `pydantic-core` now is `no_coverage`, we can enabled it automatically on Rust nightly and disable it on stable Rust to support build on stable Rust toolchain.