### PR TITLE
perf: use `Cow` in `EitherString`

### DIFF
--- a/src/input/input_json.rs
+++ b/src/input/input_json.rs
@@ -23,14 +23,14 @@ impl<'a> Input<'a> for JsonInput {
 
     fn strict_str<'data>(&'data self) -> ValResult<EitherString<'data>> {
         match self {
-            JsonInput::String(s) => Ok(s.to_string().into()),
+            JsonInput::String(s) => Ok(s.as_str().into()),
             _ => err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::StrType),
         }
     }
 
     fn lax_str<'data>(&'data self) -> ValResult<EitherString<'data>> {
         match self {
-            JsonInput::String(s) => Ok(s.to_string().into()),
+            JsonInput::String(s) => Ok(s.as_str().into()),
             JsonInput::Int(int) => Ok(int.to_string().into()),
             JsonInput::Float(float) => Ok(float.to_string().into()),
             _ => err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::StrType),
@@ -201,7 +201,7 @@ impl<'a> Input<'a> for String {
     }
 
     fn strict_str<'data>(&'data self) -> ValResult<EitherString<'data>> {
-        Ok(self.clone().into())
+        Ok(self.as_str().into())
     }
 
     #[cfg_attr(has_no_coverage, no_coverage)]

--- a/src/input/input_python.rs
+++ b/src/input/input_python.rs
@@ -40,7 +40,7 @@ impl<'a> Input<'a> for PyAny {
             Ok(py_str.into())
         } else if let Ok(bytes) = self.cast_as::<PyBytes>() {
             let str = match from_utf8(bytes.as_bytes()) {
-                Ok(s) => s.to_string(),
+                Ok(s) => s,
                 Err(_) => return err_val_error!(input_value = self.as_error_value(), kind = ErrorKind::StrUnicode),
             };
             Ok(str.into())

--- a/src/input/return_enums.rs
+++ b/src/input/return_enums.rs
@@ -1,23 +1,31 @@
+use std::borrow::Cow;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 
 pub enum EitherString<'a> {
-    Raw(String),
+    Raw(Cow<'a, str>),
     Py(&'a PyString),
 }
 
 impl<'a> EitherString<'a> {
     pub fn as_raw(&self) -> PyResult<String> {
         match self {
-            Self::Raw(date) => Ok(date.clone()),
+            Self::Raw(data) => Ok(data.to_string()),
             Self::Py(py_str) => py_str.extract(),
         }
     }
 }
 
 impl<'a> From<String> for EitherString<'a> {
-    fn from(date: String) -> Self {
-        Self::Raw(date)
+    fn from(data: String) -> Self {
+        Self::Raw(Cow::Owned(data))
+    }
+}
+
+impl<'a> From<&'a str> for EitherString<'a> {
+    fn from(data: &'a str) -> Self {
+        Self::Raw(Cow::Borrowed(data))
     }
 }
 


### PR DESCRIPTION
Seems like a small win in `dict_json` benchmark.

Before

```
test dict_json         ... bench:      14,610 ns/iter (+/- 215)
test dict_key_error    ... bench:      11,396 ns/iter (+/- 147)
test dict_python       ... bench:       5,780 ns/iter (+/- 114)
test ints_json         ... bench:          26 ns/iter (+/- 1)
test ints_python       ... bench:          12 ns/iter (+/- 0)
test list_any_json     ... bench:       2,434 ns/iter (+/- 19)
test list_any_python   ... bench:         907 ns/iter (+/- 14)
test list_error_json   ... bench:       3,121 ns/iter (+/- 17)
test list_error_python ... bench:       3,595 ns/iter (+/- 22)
test list_int_json     ... bench:       2,464 ns/iter (+/- 14)
test list_int_python   ... bench:       1,892 ns/iter (+/- 28)
test model_json        ... bench:       1,589 ns/iter (+/- 9,252)
test model_python      ... bench:         898 ns/iter (+/- 15,014)
```

After:

```
test dict_json         ... bench:      13,721 ns/iter (+/- 207)
test dict_key_error    ... bench:      11,459 ns/iter (+/- 70)
test dict_python       ... bench:       5,457 ns/iter (+/- 193)
test ints_json         ... bench:          26 ns/iter (+/- 1)
test ints_python       ... bench:          12 ns/iter (+/- 0)
test list_any_json     ... bench:       2,484 ns/iter (+/- 11)
test list_any_python   ... bench:         922 ns/iter (+/- 10)
test list_error_json   ... bench:       3,127 ns/iter (+/- 296)
test list_error_python ... bench:       3,650 ns/iter (+/- 47)
test list_int_json     ... bench:       2,476 ns/iter (+/- 12)
test list_int_python   ... bench:       1,961 ns/iter (+/- 51)
test model_json        ... bench:       1,543 ns/iter (+/- 64)
test model_python      ... bench:         891 ns/iter (+/- 9,924)
```