### PR TITLE
Renaming schema keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example of usage:
 from pydantic_core import SchemaValidator, ValidationError
 
 v = SchemaValidator({
-    'type': 'model',
+    'type': 'typed-dict',
     'fields': {
         'name': {
             'schema': {
@@ -45,10 +45,6 @@ v = SchemaValidator({
         },
     },
 })
-print(v)
-"""
-SchemaValidator(title="MyModel", validator=ModelValidator ...
-"""
 
 r1 = v.validate_python({'name': 'Samuel', 'age': 35})
 assert r1 == {'name': 'Samuel', 'age': 35, 'is_developer': True}

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -47,7 +47,7 @@ fn ints_python(bench: &mut Bencher) {
 fn list_int_json(bench: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let validator = build_schema_validator(py, "{'type': 'list', 'items': 'int'}");
+    let validator = build_schema_validator(py, "{'type': 'list', 'items_schema': 'int'}");
     let code = format!(
         "[{}]",
         (0..100).map(|x| x.to_string()).collect::<Vec<String>>().join(",")
@@ -60,7 +60,7 @@ fn list_int_json(bench: &mut Bencher) {
 }
 
 fn list_int_input(py: Python<'_>) -> (SchemaValidator, PyObject) {
-    let validator = build_schema_validator(py, "{'type': 'list', 'items': 'int'}");
+    let validator = build_schema_validator(py, "{'type': 'list', 'items_schema': 'int'}");
     let code = format!(
         "[{}]",
         (0..100).map(|x| x.to_string()).collect::<Vec<String>>().join(",")
@@ -101,7 +101,7 @@ fn list_int_python_isinstance(bench: &mut Bencher) {
 fn list_error_json(bench: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let validator = build_schema_validator(py, "{'type': 'list', 'items': 'int'}");
+    let validator = build_schema_validator(py, "{'type': 'list', 'items_schema': 'int'}");
     let code = format!(
         "[{}]",
         (0..100)
@@ -132,7 +132,7 @@ fn list_error_json(bench: &mut Bencher) {
 }
 
 fn list_error_python_input(py: Python<'_>) -> (SchemaValidator, PyObject) {
-    let validator = build_schema_validator(py, "{'type': 'list', 'items': 'int'}");
+    let validator = build_schema_validator(py, "{'type': 'list', 'items_schema': 'int'}");
     let code = format!(
         "[{}]",
         (0..100)
@@ -277,8 +277,8 @@ fn dict_value_error(bench: &mut Bencher) {
         py,
         r#"{
             'type': 'dict',
-            'keys': 'str',
-            'values': {
+            'keys_schema': 'str',
+            'values_schema': {
                 'type': 'int',
                 'lt': 0,
             },
@@ -318,13 +318,13 @@ fn dict_value_error(bench: &mut Bencher) {
 }
 
 #[bench]
-fn model_json(bench: &mut Bencher) {
+fn typed_dict_json(bench: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let validator = build_schema_validator(
         py,
         r#"{
-          'type': 'model',
+          'type': 'typed-dict',
           'extra': 'ignore',
           'fields': {
             'a': {'schema': 'int'},
@@ -350,13 +350,13 @@ fn model_json(bench: &mut Bencher) {
 }
 
 #[bench]
-fn model_python(bench: &mut Bencher) {
+fn typed_dict_python(bench: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let validator = build_schema_validator(
         py,
         r#"{
-          'type': 'model',
+          'type': 'typed-dict',
           'extra': 'ignore',
           'fields': {
             'a': {'schema': 'int'},
@@ -383,23 +383,23 @@ fn model_python(bench: &mut Bencher) {
 }
 
 #[bench]
-fn model_deep_error(bench: &mut Bencher) {
+fn typed_dict_deep_error(bench: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let validator = build_schema_validator(
         py,
         r#"{
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {
                 'field_a': {'schema': 'str'},
                 'field_b': {
                     'schema': {
-                        'type': 'model',
+                        'type': 'typed-dict',
                         'fields': {
                             'field_c': {'schema': 'str'},
                             'field_d': {
                                 'schema': {
-                                    'type': 'model',
+                                    'type': 'typed-dict',
                                     'fields': {'field_e': {'schema': 'str'}, 'field_f': {'schema': 'int'}},
                                 }
                             },
@@ -420,7 +420,7 @@ fn model_deep_error(bench: &mut Bencher) {
         Err(e) => {
             let v = e.value(py);
             // println!("error: {}", v.to_string());
-            assert_eq!(v.getattr("title").unwrap().to_string(), "model");
+            assert_eq!(v.getattr("title").unwrap().to_string(), "typed-dict");
             let error_count: i64 = v.call_method0("error_count").unwrap().extract().unwrap();
             assert_eq!(error_count, 1);
         }

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -52,12 +52,17 @@ class FloatSchema(TypedDict, total=False):
     default: float
 
 
-# TODO: function could be typed based on mode
 class FunctionSchema(TypedDict):
     type: Literal['function']
-    mode: Literal['before', 'after', 'plain', 'wrap']
+    mode: Literal['before', 'after', 'wrap']
     function: Callable[..., Any]
-    schema: NotRequired[Schema]
+    schema: Schema
+
+
+class FunctionPlainSchema(TypedDict):
+    type: Literal['function']
+    mode: Literal['plain']
+    function: Callable[..., Any]
 
 
 class IntSchema(TypedDict, total=False):
@@ -86,10 +91,10 @@ class LiteralSchema(TypedDict):
 class ModelClassSchema(TypedDict):
     type: Literal['model-class']
     class_type: type
-    model: ModelSchema
+    model: TypedDictSchema
 
 
-class ModelField(TypedDict, total=False):
+class TypedDictField(TypedDict, total=False):
     schema: Required[Schema]
     required: bool
     default: Any
@@ -97,9 +102,9 @@ class ModelField(TypedDict, total=False):
     aliases: List[List[Union[str, int]]]
 
 
-class ModelSchema(TypedDict):
-    type: Literal['model']
-    fields: Dict[str, ModelField]
+class TypedDictSchema(TypedDict):
+    type: Literal['typed-dict']
+    fields: Dict[str, TypedDictField]
     extra_validator: NotRequired[Schema]
     config: NotRequired[ConfigSchema]
     return_fields_set: NotRequired[bool]
@@ -243,10 +248,11 @@ Schema = Union[
     DictSchema,
     FloatSchema,
     FunctionSchema,
+    FunctionPlainSchema,
     IntSchema,
     ListSchema,
     LiteralSchema,
-    ModelSchema,
+    TypedDictSchema,
     ModelClassSchema,
     NoneSchema,
     NullableSchema,

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -91,7 +91,7 @@ class LiteralSchema(TypedDict):
 class ModelClassSchema(TypedDict):
     type: Literal['model-class']
     class_type: type
-    model: TypedDictSchema
+    schema: TypedDictSchema
 
 
 class TypedDictField(TypedDict, total=False):

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -77,7 +77,7 @@ class IntSchema(TypedDict, total=False):
 
 class ListSchema(TypedDict, total=False):
     type: Required[Literal['list']]
-    items: Schema  # default: AnySchema
+    items_schema: Schema  # default: AnySchema
     min_items: int
     max_items: int
     strict: bool
@@ -133,7 +133,7 @@ class RecursiveContainerSchema(TypedDict):
 
 class SetSchema(TypedDict, total=False):
     type: Required[Literal['set']]
-    items: Schema
+    items_schema: Schema  # default: AnySchema
     min_items: int
     max_items: int
     strict: bool
@@ -141,7 +141,7 @@ class SetSchema(TypedDict, total=False):
 
 class FrozenSetSchema(TypedDict, total=False):
     type: Required[Literal['frozenset']]
-    items: Schema
+    items_schema: Schema  # default: AnySchema
     min_items: int
     max_items: int
     strict: bool
@@ -202,15 +202,15 @@ class DatetimeSchema(TypedDict, total=False):
     default: datetime
 
 
-class TupleFixLenSchema(TypedDict, total=False):
-    type: Required[Literal['tuple-fix-len']]
-    items: List[Schema]
-    strict: bool
+class TupleFixLenSchema(TypedDict):
+    type: Literal['tuple-fix-len']
+    items_schema: List[Schema]
+    strict: NotRequired[bool]
 
 
 class TupleVarLenSchema(TypedDict, total=False):
     type: Required[Literal['tuple-var-len']]
-    items: Required[Schema]
+    items_schema: Schema  # default: AnySchema
     min_items: int
     max_items: int
     strict: bool

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -34,8 +34,8 @@ class ConfigSchema(TypedDict, total=False):
 
 class DictSchema(TypedDict, total=False):
     type: Required[Literal['dict']]
-    keys: Schema  # default: AnySchema
-    values: Schema  # default: AnySchema
+    keys_schema: Schema  # default: AnySchema
+    values_schema: Schema  # default: AnySchema
     min_items: int
     max_items: int
     strict: bool

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -8,7 +8,7 @@ pub enum ErrorKind {
     #[strum(message = "Invalid JSON: {parser_error}")]
     InvalidJson,
     // ---------------------
-    // model specific errors
+    // typed dict specific errors
     #[strum(message = "Value must be a valid dictionary or instance to extract fields from")]
     DictAttributesType,
     #[strum(message = "Field required")]
@@ -18,7 +18,7 @@ pub enum ErrorKind {
     #[strum(message = "Model keys must be strings")]
     InvalidKey,
     #[strum(message = "Error extracting attribute: {error}")]
-    ModelAttributeError,
+    GetAttributeError,
     // ---------------------
     // model class specific errors
     #[strum(message = "Value must be an instance of {class_name}")]

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -27,11 +27,11 @@ impl BuildValidator for DictValidator {
     ) -> PyResult<CombinedValidator> {
         Ok(Self {
             strict: is_strict(schema, config)?,
-            key_validator: match schema.get_item("keys") {
+            key_validator: match schema.get_item("keys_schema") {
                 Some(schema) => Box::new(build_validator(schema, config, build_context)?.0),
                 None => Box::new(AnyValidator::build(schema, config, build_context)?),
             },
-            value_validator: match schema.get_item("values") {
+            value_validator: match schema.get_item("values_schema") {
                 Some(d) => Box::new(build_validator(d, config, build_context)?.0),
                 None => Box::new(AnyValidator::build(schema, config, build_context)?),
             },

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -135,11 +135,15 @@ pub struct FunctionPlainValidator {
 
 impl FunctionPlainValidator {
     pub fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<CombinedValidator> {
-        Ok(Self {
-            func: get_function(schema)?,
-            config: config.map(|c| c.into()),
+        if schema.get_item("schema").is_some() {
+            py_error!("Plain functions should not include a sub-schema")
+        } else {
+            Ok(Self {
+                func: get_function(schema)?,
+                config: config.map(|c| c.into()),
+            }
+            .into())
         }
-        .into())
     }
 }
 

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -25,7 +25,7 @@ macro_rules! sequence_build_function {
         ) -> PyResult<CombinedValidator> {
             Ok(Self {
                 strict: is_strict(schema, config)?,
-                item_validator: match schema.get_item("items") {
+                item_validator: match schema.get_item("items_schema") {
                     Some(d) => Box::new(build_validator(d, config, build_context)?.0),
                     None => Box::new(AnyValidator::build(schema, config, build_context)?),
                 },

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -23,7 +23,6 @@ mod function;
 mod int;
 mod list;
 mod literal;
-mod model;
 mod model_class;
 mod none;
 mod nullable;
@@ -32,6 +31,7 @@ mod set;
 mod string;
 mod time;
 mod tuple;
+mod typed_dict;
 mod union;
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
@@ -191,8 +191,8 @@ pub fn build_validator<'a>(
         dict,
         config,
         build_context,
-        // models e.g. heterogeneous dicts
-        model::ModelValidator,
+        // typed dict e.g. heterogeneous dicts or simply a model
+        typed_dict::TypedDictValidator,
         // unions
         union::UnionValidator,
         // nullables
@@ -254,8 +254,8 @@ pub struct Extra<'a> {
 #[derive(Debug, Clone)]
 #[enum_dispatch]
 pub enum CombinedValidator {
-    // models e.g. heterogeneous dicts
-    Model(model::ModelValidator),
+    // typed dict e.g. heterogeneous dicts or simply a model
+    Model(typed_dict::TypedDictValidator),
     // unions
     Union(union::UnionValidator),
     // nullables

--- a/src/validators/model_class.rs
+++ b/src/validators/model_class.rs
@@ -30,13 +30,13 @@ impl BuildValidator for ModelClassValidator {
     ) -> PyResult<CombinedValidator> {
         let class: &PyType = schema.get_as_req("class_type")?;
 
-        let model_schema_raw: &PyAny = schema.get_as_req("model")?;
-        let (validator, model_schema) = build_validator(model_schema_raw, config, build_context)?;
-        let model_type: String = model_schema.get_as_req("type")?;
-        if &model_type != "typed-dict" {
-            return py_error!("model-class expected a 'typed-dict' schema, got '{}'", model_type);
+        let sub_schema: &PyAny = schema.get_as_req("schema")?;
+        let (validator, td_schema) = build_validator(sub_schema, config, build_context)?;
+        let schema_type: String = td_schema.get_as_req("type")?;
+        if &schema_type != "typed-dict" {
+            return py_error!("model-class expected a 'typed-dict' schema, got '{}'", schema_type);
         }
-        let return_fields_set = model_schema.get_as("return_fields_set")?.unwrap_or(false);
+        let return_fields_set = td_schema.get_as("return_fields_set")?.unwrap_or(false);
         if !return_fields_set {
             return py_error!(r#"model-class inner schema must have "return_fields_set" set to True"#);
         }

--- a/src/validators/model_class.rs
+++ b/src/validators/model_class.rs
@@ -33,12 +33,12 @@ impl BuildValidator for ModelClassValidator {
         let model_schema_raw: &PyAny = schema.get_as_req("model")?;
         let (validator, model_schema) = build_validator(model_schema_raw, config, build_context)?;
         let model_type: String = model_schema.get_as_req("type")?;
-        if &model_type != "model" {
-            return py_error!("model-class expected a 'model' schema, got '{}'", model_type);
+        if &model_type != "typed-dict" {
+            return py_error!("model-class expected a 'typed-dict' schema, got '{}'", model_type);
         }
         let return_fields_set = model_schema.get_as("return_fields_set")?.unwrap_or(false);
         if !return_fields_set {
-            return py_error!(r#"model-class inner model must have "return_fields_set" set to True"#);
+            return py_error!(r#"model-class inner schema must have "return_fields_set" set to True"#);
         }
 
         Ok(Self {

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -100,7 +100,7 @@ impl BuildValidator for TupleFixLenValidator {
         config: Option<&PyDict>,
         build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
-        let items: &PyList = schema.get_as_req("items")?;
+        let items: &PyList = schema.get_as_req("items_schema")?;
         if items.is_empty() {
             return py_error!("Missing schemas for tuple elements");
         }

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -13,7 +13,7 @@ def schema(*, strict: bool = False) -> dict:
         'type': 'model-class',
         'class_type': MyModel,
         'model': {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'strict': strict},
             'return_fields_set': True,
             'fields': {
@@ -65,7 +65,7 @@ def schema(*, strict: bool = False) -> dict:
                         'choices': [
                             'str',
                             {
-                                'type': 'model',
+                                'type': 'typed-dict',
                                 'fields': {
                                     'field_str': {'schema': 'str'},
                                     'field_int': {'schema': 'int'},
@@ -73,7 +73,7 @@ def schema(*, strict: bool = False) -> dict:
                                 },
                             },
                             {
-                                'type': 'model',
+                                'type': 'typed-dict',
                                 'fields': {
                                     'field_float': {'schema': 'float'},
                                     'field_bytes': {'schema': 'bytes'},
@@ -85,7 +85,7 @@ def schema(*, strict: bool = False) -> dict:
                 },
                 'field_functions_model': {
                     'schema': {
-                        'type': 'model',
+                        'type': 'typed-dict',
                         'fields': {
                             'field_before': {
                                 'schema': {
@@ -120,7 +120,7 @@ def schema(*, strict: bool = False) -> dict:
                         'type': 'recursive-container',
                         'name': 'Branch',
                         'schema': {
-                            'type': 'model',
+                            'type': 'typed-dict',
                             'fields': {
                                 'name': {'schema': 'str'},
                                 'sub_branch': {

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -12,7 +12,7 @@ def schema(*, strict: bool = False) -> dict:
     return {
         'type': 'model-class',
         'class_type': MyModel,
-        'model': {
+        'schema': {
             'type': 'typed-dict',
             'config': {'strict': strict},
             'return_fields_set': True,

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -58,7 +58,7 @@ def schema(*, strict: bool = False) -> dict:
                     'schema': {'type': 'tuple-fix-len', 'items_schema': ['str', 'int', 'float', 'bool']}
                 },
                 'field_dict_any': {'schema': 'dict'},
-                'field_dict_str_float': {'schema': {'type': 'dict', 'key': 'str', 'values': 'float'}},
+                'field_dict_str_float': {'schema': {'type': 'dict', 'keys_schema': 'str', 'values_schema': 'float'}},
                 'field_literal_1_int': {'schema': {'type': 'literal', 'expected': [1]}},
                 'field_literal_1_str': {'schema': {'type': 'literal', 'expected': ['foobar']}},
                 'field_literal_mult_int': {'schema': {'type': 'literal', 'expected': [1, 2, 3]}},

--- a/tests/benchmarks/complete_schema.py
+++ b/tests/benchmarks/complete_schema.py
@@ -35,22 +35,28 @@ def schema(*, strict: bool = False) -> dict:
                     'schema': {'type': 'datetime', 'ge': '2000-01-01T06:00:00', 'lt': '2020-01-02T12:13:14'}
                 },
                 'field_list_any': {'schema': 'list'},
-                'field_list_str': {'schema': {'type': 'list', 'items': 'str'}},
-                'field_list_str_con': {'schema': {'type': 'list', 'items': 'str', 'min_items': 3, 'max_items': 42}},
+                'field_list_str': {'schema': {'type': 'list', 'items_schema': 'str'}},
+                'field_list_str_con': {
+                    'schema': {'type': 'list', 'items_schema': 'str', 'min_items': 3, 'max_items': 42}
+                },
                 'field_set_any': {'schema': 'set'},
-                'field_set_int': {'schema': {'type': 'set', 'items': 'int'}},
-                'field_set_int_con': {'schema': {'type': 'set', 'items': 'int', 'min_items': 3, 'max_items': 42}},
+                'field_set_int': {'schema': {'type': 'set', 'items_schema': 'int'}},
+                'field_set_int_con': {
+                    'schema': {'type': 'set', 'items_schema': 'int', 'min_items': 3, 'max_items': 42}
+                },
                 'field_frozenset_any': {'schema': 'frozenset'},
-                'field_frozenset_bytes': {'schema': {'type': 'frozenset', 'items': 'bytes'}},
+                'field_frozenset_bytes': {'schema': {'type': 'frozenset', 'items_schema': 'bytes'}},
                 'field_frozenset_bytes_con': {
-                    'schema': {'type': 'frozenset', 'items': 'bytes', 'min_items': 3, 'max_items': 42}
+                    'schema': {'type': 'frozenset', 'items_schema': 'bytes', 'min_items': 3, 'max_items': 42}
                 },
                 'field_tuple_var_len_any': {'schema': 'tuple-var-len'},
-                'field_tuple_var_len_float': {'schema': {'type': 'tuple-var-len', 'items': 'float'}},
+                'field_tuple_var_len_float': {'schema': {'type': 'tuple-var-len', 'items_schema': 'float'}},
                 'field_tuple_var_len_float_con': {
-                    'schema': {'type': 'tuple-var-len', 'items': 'float', 'min_items': 3, 'max_items': 42}
+                    'schema': {'type': 'tuple-var-len', 'items_schema': 'float', 'min_items': 3, 'max_items': 42}
                 },
-                'field_tuple_fix_len': {'schema': {'type': 'tuple-fix-len', 'items': ['str', 'int', 'float', 'bool']}},
+                'field_tuple_fix_len': {
+                    'schema': {'type': 'tuple-fix-len', 'items_schema': ['str', 'int', 'float', 'bool']}
+                },
                 'field_dict_any': {'schema': 'dict'},
                 'field_dict_str_float': {'schema': {'type': 'dict', 'key': 'str', 'values': 'float'}},
                 'field_literal_1_int': {'schema': {'type': 'literal', 'expected': [1]}},
@@ -58,7 +64,9 @@ def schema(*, strict: bool = False) -> dict:
                 'field_literal_mult_int': {'schema': {'type': 'literal', 'expected': [1, 2, 3]}},
                 'field_literal_mult_str': {'schema': {'type': 'literal', 'expected': ['foo', 'bar', 'baz']}},
                 'field_literal_assorted': {'schema': {'type': 'literal', 'expected': [1, 'foo', True]}},
-                'field_list_nullable_int': {'schema': {'type': 'list', 'items': {'type': 'nullable', 'schema': 'int'}}},
+                'field_list_nullable_int': {
+                    'schema': {'type': 'list', 'items_schema': {'type': 'nullable', 'schema': 'int'}}
+                },
                 'field_union': {
                     'schema': {
                         'type': 'union',

--- a/tests/benchmarks/test_complete_benchmark.py
+++ b/tests/benchmarks/test_complete_benchmark.py
@@ -91,7 +91,7 @@ def test_complete_invalid():
     lax_validator = SchemaValidator(lax_schema)
     with pytest.raises(ValidationError) as exc_info:
         lax_validator.validate_python(input_data_wrong())
-    assert len(exc_info.value.errors()) == 636
+    assert len(exc_info.value.errors()) == 736
 
     model = pydantic_model()
     if model is None:

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -41,7 +41,7 @@ class TestBenchmarkSimpleModel:
             {
                 'type': 'model-class',
                 'class_type': CoreModel,
-                'model': {
+                'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
@@ -142,7 +142,7 @@ def test_small_class_core_model(benchmark):
         {
             'type': 'model-class',
             'class_type': MyCoreModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'name': {'schema': {'type': 'str'}}, 'age': {'schema': {'type': 'int'}}},
@@ -194,7 +194,7 @@ def test_recursive_model_core(recursive_model_data, benchmark):
             'schema': {
                 'type': 'model-class',
                 'class_type': CoreBranch,
-                'model': {
+                'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
@@ -463,7 +463,7 @@ def test_many_models_core_model(benchmark):
             'items': {
                 'type': 'model-class',
                 'class_type': MyCoreModel,
-                'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'age': {'schema': 'int'}}},
+                'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'age': {'schema': 'int'}}},
             },
         }
     )
@@ -525,7 +525,7 @@ class TestBenchmarkDateTime:
             {
                 'type': 'model-class',
                 'class_type': CoreModel,
-                'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'dt': {'schema': 'datetime'}}},
+                'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'dt': {'schema': 'datetime'}}},
             }
         )
 

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -42,7 +42,7 @@ class TestBenchmarkSimpleModel:
                 'type': 'model-class',
                 'class_type': CoreModel,
                 'model': {
-                    'type': 'model',
+                    'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
                         'name': {'schema': {'type': 'str'}},
@@ -122,7 +122,7 @@ def test_small_class_pyd(benchmark):
 @pytest.mark.benchmark(group='create small model')
 def test_small_class_core_dict(benchmark):
     model_schema = {
-        'type': 'model',
+        'type': 'typed-dict',
         'fields': {'name': {'schema': {'type': 'str'}}, 'age': {'schema': {'type': 'int'}}},
     }
     dict_schema_validator = SchemaValidator(model_schema)
@@ -143,7 +143,7 @@ def test_small_class_core_model(benchmark):
             'type': 'model-class',
             'class_type': MyCoreModel,
             'model': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'name': {'schema': {'type': 'str'}}, 'age': {'schema': {'type': 'int'}}},
             },
@@ -195,7 +195,7 @@ def test_recursive_model_core(recursive_model_data, benchmark):
                 'type': 'model-class',
                 'class_type': CoreBranch,
                 'model': {
-                    'type': 'model',
+                    'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
                         'width': {'schema': {'type': 'int'}},
@@ -227,7 +227,11 @@ def test_list_of_dict_models_pyd(benchmark):
 @pytest.mark.benchmark(group='List[TypedDict]')
 def test_list_of_dict_models_core(benchmark):
     v = SchemaValidator(
-        {'type': 'list', 'name': 'Branch', 'items': {'type': 'model', 'fields': {'width': {'schema': {'type': 'int'}}}}}
+        {
+            'type': 'list',
+            'name': 'Branch',
+            'items': {'type': 'typed-dict', 'fields': {'width': {'schema': {'type': 'int'}}}},
+        }
     )
 
     data = [{'width': i} for i in range(100)]
@@ -443,7 +447,7 @@ def test_many_models_pyd(benchmark):
 
 @pytest.mark.benchmark(group='List[DictSimpleMode]')
 def test_many_models_core_dict(benchmark):
-    model_schema = {'type': 'list', 'items': {'type': 'model', 'fields': {'age': {'schema': 'int'}}}}
+    model_schema = {'type': 'list', 'items': {'type': 'typed-dict', 'fields': {'age': {'schema': 'int'}}}}
     v = SchemaValidator(model_schema)
     benchmark(v.validate_python, many_models_data)
 
@@ -459,7 +463,7 @@ def test_many_models_core_model(benchmark):
             'items': {
                 'type': 'model-class',
                 'class_type': MyCoreModel,
-                'model': {'type': 'model', 'return_fields_set': True, 'fields': {'age': {'schema': 'int'}}},
+                'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'age': {'schema': 'int'}}},
             },
         }
     )
@@ -521,7 +525,7 @@ class TestBenchmarkDateTime:
             {
                 'type': 'model-class',
                 'class_type': CoreModel,
-                'model': {'type': 'model', 'return_fields_set': True, 'fields': {'dt': {'schema': 'datetime'}}},
+                'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'dt': {'schema': 'datetime'}}},
             }
         )
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -22,10 +22,14 @@ def test_build_error_internal():
 def test_build_error_deep():
     with pytest.raises(SchemaError) as exc_info:
         SchemaValidator(
-            {'title': 'MyTestModel', 'type': 'model', 'fields': {'age': {'schema': {'type': 'int', 'ge': 'not-int'}}}}
+            {
+                'title': 'MyTestModel',
+                'type': 'typed-dict',
+                'fields': {'age': {'schema': {'type': 'int', 'ge': 'not-int'}}},
+            }
         )
     assert str(exc_info.value) == (
-        'Error building "model" validator:\n'
+        'Error building "typed-dict" validator:\n'
         '  SchemaError: Field "age":\n'
         '  SchemaError: Error building "int" validator:\n'
         "  TypeError: 'str' object cannot be interpreted as an integer"
@@ -66,8 +70,8 @@ def test_schema_recursive_error():
 
 def test_not_schema_recursive_error():
     schema = {
-        'type': 'model',
+        'type': 'typed-dict',
         'fields': {f'f_{i}': {'schema': {'type': 'nullable', 'schema': 'int'}} for i in range(101)},
     }
     v = SchemaValidator(schema)
-    assert repr(v).count('ModelField') == 101
+    assert repr(v).count('TypedDictField') == 101

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -51,7 +51,7 @@ def test_internal_error():
         {
             'type': 'model-class',
             'class_type': int,
-            'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
+            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
         }
     )
     with pytest.raises(AttributeError, match="'int' object has no attribute '__dict__'"):

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -51,7 +51,7 @@ def test_internal_error():
         {
             'type': 'model-class',
             'class_type': int,
-            'model': {'type': 'model', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
+            'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
         }
     )
     with pytest.raises(AttributeError, match="'int' object has no attribute '__dict__'"):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -34,7 +34,10 @@ def test_float(input_value, output_value):
 
 def test_model():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+        }
     )
 
     # language=json
@@ -50,7 +53,7 @@ def test_float_no_remainder():
 def test_error_loc():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'list', 'items': {'type': 'int'}}}},
             'extra_validator': {'type': 'int'},

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -76,12 +76,12 @@ def test_error_loc():
 
 
 def test_dict():
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_json('{"1": 2, "3": 4}') == {1: 2, 3: 4}
 
 
 def test_dict_any_value():
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'str'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'str'}})
     assert v.validate_json('{"1": 1, "2": "a", "3": null}') == {'1': 1, '2': 'a', '3': None}
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -55,7 +55,7 @@ def test_error_loc():
         {
             'type': 'typed-dict',
             'return_fields_set': True,
-            'fields': {'field_a': {'schema': {'type': 'list', 'items': {'type': 'int'}}}},
+            'fields': {'field_a': {'schema': {'type': 'list', 'items_schema': {'type': 'int'}}}},
             'extra_validator': {'type': 'int'},
             'config': {'extra_behavior': 'allow'},
         }

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -44,7 +44,7 @@ def test_validation_error_multiple():
             'type': 'model-class',
             'class_type': MyModel,
             'model': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'x': {'schema': {'type': 'float'}}, 'y': {'schema': {'type': 'int'}}},
             },

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -43,7 +43,7 @@ def test_validation_error_multiple():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'x': {'schema': {'type': 'float'}}, 'y': {'schema': {'type': 'int'}}},

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -48,7 +48,7 @@ def test_schema_typing() -> None:
     schema: Schema = {
         'type': 'model-class',
         'class_type': Foo,
-        'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': {'type': 'str'}}}},
+        'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': {'type': 'str'}}}},
     }
     SchemaValidator(schema)
     schema: Schema = {

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, time
 
+import pytest
+
 from pydantic_core import Schema, SchemaError, SchemaValidator
 
 
@@ -13,65 +15,86 @@ def foo(bar: str) -> None:
 
 def test_schema_typing() -> None:
     # this gets run by pyright, but we also check that it executes
-    _: Schema = {
-        'type': 'union',
-        'choices': [
-            'int',
-            {'type': 'int', 'ge': 1},
-            {'type': 'float', 'lt': 1.0},
-            {'type': 'str', 'pattern': r'http:\/\/.*'},
-            {'type': 'bool', 'strict': False},
-            {'type': 'literal', 'expected': [1, '1']},
-            {'type': 'any'},
-            {'type': 'none'},
-            {'type': 'bytes'},
-            {'type': 'list', 'items': {'type': 'str'}, 'min_items': 3},
-            {'type': 'set', 'items': {'type': 'str'}, 'max_items': 3},
-            {'type': 'tuple-var-len', 'items': {'type': 'str'}, 'max_items': 3},
-            {'type': 'tuple-fix-len', 'items': [{'type': 'str'}, {'type': 'int'}]},
-            {'type': 'frozenset', 'items': {'type': 'str'}, 'max_items': 3},
-            {'type': 'dict', 'keys': {'type': 'str'}, 'values': {'type': 'any'}},
-            {
-                'type': 'model-class',
-                'class_type': Foo,
-                'model': {'type': 'model', 'fields': {'bar': {'schema': {'type': 'str'}}}},
-            },
-            {
-                'type': 'model',
-                'fields': {
-                    'a': {'schema': {'type': 'str'}},
-                    'b': {'schema': {'type': 'str'}, 'alias': 'foobar'},
-                    'c': {'schema': {'type': 'str'}, 'aliases': [['foobar', 0, 'bar'], ['foo']]},
-                    'd': {'schema': {'type': 'str'}, 'default': 'spam'},
-                },
-            },
-            {'type': 'function', 'mode': 'wrap', 'function': foo},
-            {
-                'type': 'recursive-container',
-                'name': 'Branch',
-                'schema': {
-                    'type': 'model',
-                    'fields': {
-                        'name': {'schema': {'type': 'str'}},
-                        'sub_branch': {
-                            'schema': {
-                                'type': 'union',
-                                'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
-                            },
-                            'default': None,
-                        },
-                    },
-                },
-            },
-            {'type': 'date', 'le': date.today()},
-            {'type': 'time', 'lt': time(12, 13, 14)},
-            {'type': 'datetime', 'ge': datetime.now()},
-        ],
+    schema: Schema = {'type': 'union', 'choices': ['int', {'type': 'int', 'ge': 1}, {'type': 'float', 'lt': 1.0}]}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'int', 'ge': 1}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'float', 'lt': 1.0}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'str', 'pattern': r'http://.*'}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'bool', 'strict': False}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'literal', 'expected': [1, '1']}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'any'}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'none'}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'bytes'}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'list', 'items': {'type': 'str'}, 'min_items': 3}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'set', 'items': {'type': 'str'}, 'max_items': 3}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'tuple-var-len', 'items': {'type': 'str'}, 'max_items': 3}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'tuple-fix-len', 'items': [{'type': 'str'}, {'type': 'int'}]}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'frozenset', 'items': {'type': 'str'}, 'max_items': 3}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'dict', 'keys': {'type': 'str'}, 'values': {'type': 'any'}}
+    SchemaValidator(schema)
+    schema: Schema = {
+        'type': 'model-class',
+        'class_type': Foo,
+        'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': {'type': 'str'}}}},
     }
+    SchemaValidator(schema)
+    schema: Schema = {
+        'type': 'typed-dict',
+        'fields': {
+            'a': {'schema': {'type': 'str'}},
+            'b': {'schema': {'type': 'str'}, 'alias': 'foobar'},
+            'c': {'schema': {'type': 'str'}, 'aliases': [['foobar', 0, 'bar'], ['foo']]},
+            'd': {'schema': {'type': 'str'}, 'default': 'spam'},
+        },
+    }
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'function', 'mode': 'wrap', 'function': foo, 'schema': {'type': 'str'}}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'function', 'mode': 'plain', 'function': foo}
+    SchemaValidator(schema)
+    schema: Schema = {
+        'type': 'recursive-container',
+        'name': 'Branch',
+        'schema': {
+            'type': 'typed-dict',
+            'fields': {
+                'name': {'schema': {'type': 'str'}},
+                'sub_branch': {
+                    'schema': {
+                        'type': 'union',
+                        'choices': [{'type': 'none'}, {'type': 'recursive-ref', 'name': 'Branch'}],
+                    },
+                    'default': None,
+                },
+            },
+        },
+    }
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'date', 'le': date.today()}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'time', 'lt': time(12, 13, 14)}
+    SchemaValidator(schema)
+    schema: Schema = {'type': 'datetime', 'ge': datetime.now()}
+    SchemaValidator(schema)
 
 
 def test_schema_typing_error() -> None:
-    _: Schema = {'type': 'wrong'}  # type: ignore
+    schema: Schema = {'type': 'wrong'}  # type: ignore
+    with pytest.raises(SchemaError, match='Unknown schema type: "wrong"'):
+        SchemaValidator(schema)
 
 
 def test_schema_validator() -> None:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -33,15 +33,15 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: Schema = {'type': 'bytes'}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'list', 'items': {'type': 'str'}, 'min_items': 3}
+    schema: Schema = {'type': 'list', 'items_schema': {'type': 'str'}, 'min_items': 3}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'set', 'items': {'type': 'str'}, 'max_items': 3}
+    schema: Schema = {'type': 'set', 'items_schema': {'type': 'str'}, 'max_items': 3}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'tuple-var-len', 'items': {'type': 'str'}, 'max_items': 3}
+    schema: Schema = {'type': 'tuple-var-len', 'items_schema': {'type': 'str'}, 'max_items': 3}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'tuple-fix-len', 'items': [{'type': 'str'}, {'type': 'int'}]}
+    schema: Schema = {'type': 'tuple-fix-len', 'items_schema': [{'type': 'str'}, {'type': 'int'}]}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'frozenset', 'items': {'type': 'str'}, 'max_items': 3}
+    schema: Schema = {'type': 'frozenset', 'items_schema': {'type': 'str'}, 'max_items': 3}
     SchemaValidator(schema)
     schema: Schema = {'type': 'dict', 'keys': {'type': 'str'}, 'values': {'type': 'any'}}
     SchemaValidator(schema)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -43,7 +43,7 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: Schema = {'type': 'frozenset', 'items_schema': {'type': 'str'}, 'max_items': 3}
     SchemaValidator(schema)
-    schema: Schema = {'type': 'dict', 'keys': {'type': 'str'}, 'values': {'type': 'any'}}
+    schema: Schema = {'type': 'dict', 'keys_schema': {'type': 'str'}, 'values_schema': {'type': 'any'}}
     SchemaValidator(schema)
     schema: Schema = {
         'type': 'model-class',

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,7 +1,5 @@
 from datetime import date, datetime, time
 
-import pytest
-
 from pydantic_core import Schema, SchemaError, SchemaValidator
 
 
@@ -92,9 +90,7 @@ def test_schema_typing() -> None:
 
 
 def test_schema_typing_error() -> None:
-    schema: Schema = {'type': 'wrong'}  # type: ignore
-    with pytest.raises(SchemaError, match='Unknown schema type: "wrong"'):
-        SchemaValidator(schema)
+    _: Schema = {'type': 'wrong'}  # type: ignore
 
 
 def test_schema_validator() -> None:

--- a/tests/validators/test_date.py
+++ b/tests/validators/test_date.py
@@ -164,12 +164,12 @@ def test_invalid_constraint():
 
 
 def test_dict_py():
-    v = SchemaValidator({'type': 'dict', 'keys': 'date', 'values': 'int'})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': 'date', 'values_schema': 'int'})
     assert v.validate_python({date(2000, 1, 1): 2, date(2000, 1, 2): 4}) == {date(2000, 1, 1): 2, date(2000, 1, 2): 4}
 
 
 def test_dict(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': 'date', 'values': 'int'})
+    v = py_or_json({'type': 'dict', 'keys_schema': 'date', 'values_schema': 'int'})
     assert v.validate_test({'2000-01-01': 2, '2000-01-02': 4}) == {date(2000, 1, 1): 2, date(2000, 1, 2): 4}
 
 

--- a/tests/validators/test_datetime.py
+++ b/tests/validators/test_datetime.py
@@ -223,7 +223,7 @@ def test_custom_invalid_tz():
 
 
 def test_dict_py():
-    v = SchemaValidator({'type': 'dict', 'keys': 'datetime', 'values': 'int'})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': 'datetime', 'values_schema': 'int'})
     assert v.validate_python({datetime(2000, 1, 1): 2, datetime(2000, 1, 2): 4}) == {
         datetime(2000, 1, 1): 2,
         datetime(2000, 1, 2): 4,
@@ -231,7 +231,7 @@ def test_dict_py():
 
 
 def test_dict(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': 'datetime', 'values': 'int'})
+    v = py_or_json({'type': 'dict', 'keys_schema': 'datetime', 'values_schema': 'int'})
     assert v.validate_test({'2000-01-01T00:00': 2, '2000-01-02T00:00': 4}) == {
         datetime(2000, 1, 1): 2,
         datetime(2000, 1, 2): 4,

--- a/tests/validators/test_dict.py
+++ b/tests/validators/test_dict.py
@@ -11,9 +11,9 @@ from ..conftest import Err
 
 
 def test_dict(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = py_or_json({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_test({'1': 2, '3': 4}) == {1: 2, 3: 4}
-    v = py_or_json({'type': 'dict', 'strict': True, 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = py_or_json({'type': 'dict', 'strict': True, 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_test({'1': 2, '3': 4}) == {1: 2, 3: 4}
     assert v.validate_test({}) == {}
     with pytest.raises(ValidationError, match='Value must be a valid dictionary'):
@@ -37,7 +37,7 @@ def test_dict(py_or_json):
     ids=repr,
 )
 def test_dict_cases(input_value, expected):
-    v = SchemaValidator({'type': 'dict', 'keys': 'str', 'values': 'str'})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': 'str', 'values_schema': 'str'})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -46,7 +46,7 @@ def test_dict_cases(input_value, expected):
 
 
 def test_dict_value_error(py_or_json):
-    v = py_or_json({'type': 'dict', 'values': 'int'})
+    v = py_or_json({'type': 'dict', 'values_schema': 'int'})
     assert v.validate_test({'a': 2, 'b': '4'}) == {'a': 2, 'b': 4}
     with pytest.raises(ValidationError, match='Value must be a valid integer') as exc_info:
         v.validate_test({'a': 2, 'b': 'wrong'})
@@ -61,7 +61,7 @@ def test_dict_value_error(py_or_json):
 
 
 def test_dict_error_key_int():
-    v = SchemaValidator({'type': 'dict', 'values': 'int'})
+    v = SchemaValidator({'type': 'dict', 'values_schema': 'int'})
     with pytest.raises(ValidationError, match='Value must be a valid integer') as exc_info:
         v.validate_python({1: 2, 3: 'wrong'})
     assert exc_info.value.errors() == [
@@ -75,7 +75,7 @@ def test_dict_error_key_int():
 
 
 def test_dict_error_key_other():
-    v = SchemaValidator({'type': 'dict', 'values': 'int'})
+    v = SchemaValidator({'type': 'dict', 'values_schema': 'int'})
     with pytest.raises(ValidationError, match='Value must be a valid integer') as exc_info:
         v.validate_python({1: 2, (1, 2): 'wrong'})
     assert exc_info.value.errors() == [
@@ -89,8 +89,8 @@ def test_dict_error_key_other():
 
 
 def test_dict_any_value():
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'str'}})
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'str'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'str'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'str'}})
     assert v.validate_python({'1': 1, '2': 'a', '3': None}) == {'1': 1, '2': 'a', '3': None}
 
 
@@ -108,15 +108,17 @@ def test_mapping():
         def __len__(self):
             return len(self._d)
 
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_python(MyMapping({'1': 2, 3: '4'})) == {1: 2, 3: 4}
-    v = SchemaValidator({'type': 'dict', 'strict': True, 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator(
+        {'type': 'dict', 'strict': True, 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}}
+    )
     with pytest.raises(ValidationError, match='Value must be a valid dictionary'):
         v.validate_python(MyMapping({'1': 2, 3: '4'}))
 
 
 def test_key_error():
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     assert v.validate_python({'1': True}) == {1: 1}
     with pytest.raises(ValidationError, match=re.escape('x -> [key]\n  Value must be a valid integer')) as exc_info:
         v.validate_python({'x': 1})
@@ -141,7 +143,7 @@ def test_mapping_error():
         def __len__(self):
             return 1
 
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(BadMapping())
 
@@ -170,7 +172,7 @@ def test_mapping_error_yield_1():
         def __len__(self):
             return 1
 
-    v = SchemaValidator({'type': 'dict', 'keys': {'type': 'int'}, 'values': {'type': 'int'}})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': {'type': 'int'}, 'values_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(BadMapping())
 

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -12,7 +12,7 @@ from ..conftest import Err
     [([], frozenset()), ([1, 2, 3], {1, 2, 3}), ([1, 2, '3'], {1, 2, 3}), ([1, 2, 3, 2, 3], {1, 2, 3})],
 )
 def test_frozenset_ints_both(py_or_json, input_value, expected):
-    v = py_or_json({'type': 'frozenset', 'items': {'type': 'int'}})
+    v = py_or_json({'type': 'frozenset', 'items_schema': {'type': 'int'}})
     output = v.validate_test(input_value)
     assert output == expected
     assert isinstance(output, frozenset)
@@ -58,7 +58,7 @@ def test_frozenset_no_validators_both(py_or_json, input_value, expected):
     ],
 )
 def test_frozenset_ints_python(input_value, expected):
-    v = SchemaValidator({'type': 'frozenset', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'frozenset', 'items_schema': {'type': 'int'}})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -77,7 +77,7 @@ def test_frozenset_no_validators_python(input_value, expected):
 
 
 def test_frozenset_multiple_errors():
-    v = SchemaValidator({'type': 'frozenset', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'frozenset', 'items_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(['a', (1, 2), []])
     assert exc_info.value.errors() == [
@@ -164,8 +164,8 @@ def test_union_frozenset_int_frozenset_str(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {'type': 'frozenset', 'items': {'type': 'int', 'strict': True}},
-                {'type': 'frozenset', 'items': {'type': 'str', 'strict': True}},
+                {'type': 'frozenset', 'items_schema': {'type': 'int', 'strict': True}},
+                {'type': 'frozenset', 'items_schema': {'type': 'str', 'strict': True}},
             ],
         }
     )

--- a/tests/validators/test_frozenset.py
+++ b/tests/validators/test_frozenset.py
@@ -181,7 +181,7 @@ def test_union_frozenset_int_frozenset_str(input_value, expected):
 
 
 def test_frozenset_as_dict_keys(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': {'type': 'frozenset'}, 'value': 'int'})
+    v = py_or_json({'type': 'dict', 'keys_schema': {'type': 'frozenset'}, 'value': 'int'})
     with pytest.raises(ValidationError, match=re.escape('Value must be a valid frozenset')):
         v.validate_test({'foo': 'bar'})
 

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -213,6 +213,11 @@ def test_function_plain():
     assert v.validate_python('x') == 'xx'
 
 
+def test_plain_schema():
+    with pytest.raises(SchemaError, match='Plain functions should not include a sub-schema'):
+        SchemaValidator({'type': 'function', 'mode': 'plain', 'function': lambda x: x, 'schema': 'str'})
+
+
 def test_validate_assignment():
     def f(input_value, **kwargs):
         input_value['more'] = 'foobar'

--- a/tests/validators/test_function.py
+++ b/tests/validators/test_function.py
@@ -79,7 +79,7 @@ def test_function_before_error_model():
             'type': 'function',
             'mode': 'before',
             'function': f,
-            'schema': {'type': 'model', 'fields': {'my_field': {'schema': {'type': 'str', 'max_length': 5}}}},
+            'schema': {'type': 'typed-dict', 'fields': {'my_field': {'schema': {'type': 'str', 'max_length': 5}}}},
         }
     )
 
@@ -150,7 +150,7 @@ def test_function_after_data():
     v = SchemaValidator(
         {
             'title': 'Test',
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {
                 'field_a': {'schema': {'type': 'int'}},
                 'field_b': {'schema': {'type': 'function', 'mode': 'after', 'function': f, 'schema': {'type': 'str'}}},
@@ -173,7 +173,7 @@ def test_function_after_config():
     v = SchemaValidator(
         {
             'title': 'Test',
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {
                 'test_field': {
                     'schema': {'type': 'function', 'mode': 'after', 'function': f, 'schema': {'type': 'str'}}
@@ -223,7 +223,7 @@ def test_validate_assignment():
             'type': 'function',
             'mode': 'after',
             'function': f,
-            'schema': {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}}},
+            'schema': {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}},
         }
     )
 

--- a/tests/validators/test_list.py
+++ b/tests/validators/test_list.py
@@ -18,7 +18,7 @@ from ..conftest import Err
     ],
 )
 def test_list_json(py_or_json, input_value, expected):
-    v = py_or_json({'type': 'list', 'items': {'type': 'int'}})
+    v = py_or_json({'type': 'list', 'items_schema': {'type': 'int'}})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)
@@ -27,7 +27,7 @@ def test_list_json(py_or_json, input_value, expected):
 
 
 def test_list_strict():
-    v = SchemaValidator({'type': 'list', 'items': {'type': 'int'}, 'strict': True})
+    v = SchemaValidator({'type': 'list', 'items_schema': {'type': 'int'}, 'strict': True})
     assert v.validate_python([1, 2, '33']) == [1, 2, 33]
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python((1, 2, '33'))
@@ -45,7 +45,7 @@ def test_list_strict():
     ],
 )
 def test_list(input_value, expected):
-    v = SchemaValidator({'type': 'list', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'list', 'items_schema': {'type': 'int'}})
     assert v.validate_python(input_value) == expected
 
 
@@ -61,7 +61,7 @@ def test_list(input_value, expected):
     ],
 )
 def test_list_error(input_value, index):
-    v = SchemaValidator({'type': 'list', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'list', 'items_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python(input_value)
     assert exc_info.value.errors() == [

--- a/tests/validators/test_model_class.py
+++ b/tests/validators/test_model_class.py
@@ -17,7 +17,7 @@ def test_model_class():
             'type': 'model-class',
             'class_type': MyModel,
             'model': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
             },
@@ -52,7 +52,11 @@ def test_model_class_setattr():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {'type': 'model', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}},
+            'model': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'field_a': {'schema': {'type': 'str'}}},
+            },
         }
     )
     m = v.validate_python({'field_a': 'test'})
@@ -80,7 +84,7 @@ def test_model_class_root_validator():
                 'type': 'model-class',
                 'class_type': MyModel,
                 'model': {
-                    'type': 'model',
+                    'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {'field_a': {'schema': {'type': 'str'}}},
                 },
@@ -96,7 +100,7 @@ def test_model_class_bad_model():
     class MyModel:
         pass
 
-    with pytest.raises(SchemaError, match=re.escape("model-class expected a 'model' schema, got 'str'")):
+    with pytest.raises(SchemaError, match=re.escape("model-class expected a 'typed-dict' schema, got 'str'")):
         SchemaValidator({'type': 'model-class', 'class_type': MyModel, 'model': {'type': 'str'}})
 
 
@@ -117,7 +121,11 @@ def test_model_class_instance_direct():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {'type': 'model', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}},
+            'model': {
+                'type': 'typed-dict',
+                'return_fields_set': True,
+                'fields': {'field_a': {'schema': {'type': 'str'}}},
+            },
         }
     )
     m1 = v.validate_python({'field_a': 'test'})
@@ -151,7 +159,7 @@ def test_model_class_instance_subclass():
             'type': 'model-class',
             'class_type': MyModel,
             'model': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}},
                 'config': {'from_attributes': True},
@@ -179,7 +187,7 @@ def test_model_class_strict():
             'strict': True,
             'class_type': MyModel,
             'model': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
             },
@@ -203,6 +211,7 @@ def test_model_class_strict():
             'context': {'class_name': 'MyModel'},
         }
     ]
+    assert str(exc_info.value).startswith('1 validation error for MyModel\n')
 
 
 def test_internal_error():
@@ -210,7 +219,7 @@ def test_internal_error():
         {
             'type': 'model-class',
             'class_type': int,
-            'model': {'type': 'model', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
+            'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
         }
     )
     with pytest.raises(AttributeError, match=re.escape("'int' object has no attribute '__dict__'")):

--- a/tests/validators/test_model_class.py
+++ b/tests/validators/test_model_class.py
@@ -16,7 +16,7 @@ def test_model_class():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
@@ -52,7 +52,7 @@ def test_model_class_setattr():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}},
@@ -83,7 +83,7 @@ def test_model_class_root_validator():
             'schema': {
                 'type': 'model-class',
                 'class_type': MyModel,
-                'model': {
+                'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {'field_a': {'schema': {'type': 'str'}}},
@@ -101,7 +101,7 @@ def test_model_class_bad_model():
         pass
 
     with pytest.raises(SchemaError, match=re.escape("model-class expected a 'typed-dict' schema, got 'str'")):
-        SchemaValidator({'type': 'model-class', 'class_type': MyModel, 'model': {'type': 'str'}})
+        SchemaValidator({'type': 'model-class', 'class_type': MyModel, 'schema': {'type': 'str'}})
 
 
 def test_model_class_not_type():
@@ -121,7 +121,7 @@ def test_model_class_instance_direct():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}},
@@ -158,7 +158,7 @@ def test_model_class_instance_subclass():
         {
             'type': 'model-class',
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}},
@@ -186,7 +186,7 @@ def test_model_class_strict():
             'type': 'model-class',
             'strict': True,
             'class_type': MyModel,
-            'model': {
+            'schema': {
                 'type': 'typed-dict',
                 'return_fields_set': True,
                 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
@@ -219,7 +219,7 @@ def test_internal_error():
         {
             'type': 'model-class',
             'class_type': int,
-            'model': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
+            'schema': {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'f': {'schema': 'int'}}},
         }
     )
     with pytest.raises(AttributeError, match=re.escape("'int' object has no attribute '__dict__'")):

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -87,7 +87,7 @@ def test_list():
                 'fields': {
                     'width': {'schema': 'int'},
                     'branches': {
-                        'schema': {'type': 'list', 'items': {'type': 'recursive-ref', 'name': 'BranchList'}},
+                        'schema': {'type': 'list', 'items_schema': {'type': 'recursive-ref', 'name': 'BranchList'}},
                         'default': None,
                     },
                 },
@@ -132,7 +132,10 @@ def test_multiple_intertwined():
                                 'fields': {
                                     'width': {'schema': 'int'},
                                     'bars': {
-                                        'schema': {'type': 'list', 'items': {'type': 'recursive-ref', 'name': 'Bar'}},
+                                        'schema': {
+                                            'type': 'list',
+                                            'items_schema': {'type': 'recursive-ref', 'name': 'Bar'},
+                                        },
                                         'default': None,
                                     },
                                     'foo': {
@@ -215,7 +218,7 @@ def test_invalid_schema():
         SchemaValidator(
             {
                 'type': 'list',
-                'items': {
+                'items_schema': {
                     'type': 'typed-dict',
                     'fields': {
                         'width': {'schema': {'type': 'int'}},

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -180,7 +180,7 @@ def test_model_class():
             'schema': {
                 'type': 'model-class',
                 'class_type': Branch,
-                'model': {
+                'schema': {
                     'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {

--- a/tests/validators/test_recursive.py
+++ b/tests/validators/test_recursive.py
@@ -11,7 +11,7 @@ def test_branch_nullable():
             'type': 'recursive-container',
             'name': 'Branch',
             'schema': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'fields': {
                     'name': {'schema': {'type': 'str'}},
                     'sub_branch': {
@@ -42,7 +42,7 @@ def test_nullable_error():
             'type': 'recursive-container',
             'name': 'Branch',
             'schema': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'fields': {
                     'width': {'schema': 'int'},
                     'sub_branch': {
@@ -83,7 +83,7 @@ def test_list():
             'type': 'recursive-container',
             'name': 'BranchList',
             'schema': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'fields': {
                     'width': {'schema': 'int'},
                     'branches': {
@@ -120,7 +120,7 @@ def test_multiple_intertwined():
             'type': 'recursive-container',
             'name': 'Foo',
             'schema': {
-                'type': 'model',
+                'type': 'typed-dict',
                 'fields': {
                     'height': {'schema': 'int'},
                     'bar': {
@@ -128,7 +128,7 @@ def test_multiple_intertwined():
                             'type': 'recursive-container',
                             'name': 'Bar',
                             'schema': {
-                                'type': 'model',
+                                'type': 'typed-dict',
                                 'fields': {
                                     'width': {'schema': 'int'},
                                     'bars': {
@@ -178,7 +178,7 @@ def test_model_class():
                 'type': 'model-class',
                 'class_type': Branch,
                 'model': {
-                    'type': 'model',
+                    'type': 'typed-dict',
                     'return_fields_set': True,
                     'fields': {
                         'width': {'schema': 'int'},
@@ -216,7 +216,7 @@ def test_invalid_schema():
             {
                 'type': 'list',
                 'items': {
-                    'type': 'model',
+                    'type': 'typed-dict',
                     'fields': {
                         'width': {'schema': {'type': 'int'}},
                         'branch': {

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -183,6 +183,6 @@ def test_union_set_int_set_str(input_value, expected):
 
 
 def test_set_as_dict_keys(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': {'type': 'set'}, 'value': 'int'})
+    v = py_or_json({'type': 'dict', 'keys_schema': {'type': 'set'}, 'value': 'int'})
     with pytest.raises(ValidationError, match=re.escape('Value must be a valid set')):
         v.validate_test({'foo': 'bar'})

--- a/tests/validators/test_set.py
+++ b/tests/validators/test_set.py
@@ -18,7 +18,7 @@ from ..conftest import Err
     ],
 )
 def test_set_ints_both(py_or_json, input_value, expected):
-    v = py_or_json({'type': 'set', 'items': {'type': 'int'}})
+    v = py_or_json({'type': 'set', 'items_schema': {'type': 'int'}})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)
@@ -69,7 +69,7 @@ def test_frozenset_no_validators_both(py_or_json, input_value, expected):
     ],
 )
 def test_set_ints_python(input_value, expected):
-    v = SchemaValidator({'type': 'set', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'set', 'items_schema': {'type': 'int'}})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_python(input_value)
@@ -84,7 +84,7 @@ def test_set_no_validators_python(input_value, expected):
 
 
 def test_set_multiple_errors():
-    v = SchemaValidator({'type': 'set', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'set', 'items_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(['a', (1, 2), []])
     assert exc_info.value.errors() == [
@@ -168,8 +168,8 @@ def test_union_set_int_set_str(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {'type': 'set', 'items': {'type': 'int', 'strict': True}},
-                {'type': 'set', 'items': {'type': 'str', 'strict': True}},
+                {'type': 'set', 'items_schema': {'type': 'int', 'strict': True}},
+                {'type': 'set', 'items_schema': {'type': 'str', 'strict': True}},
             ],
         }
     )

--- a/tests/validators/test_time.py
+++ b/tests/validators/test_time.py
@@ -151,12 +151,12 @@ def test_invalid_constraint():
 
 
 def test_dict_py():
-    v = SchemaValidator({'type': 'dict', 'keys': 'time', 'values': 'int'})
+    v = SchemaValidator({'type': 'dict', 'keys_schema': 'time', 'values_schema': 'int'})
     assert v.validate_python({time(12, 1, 1): 2, time(12, 1, 2): 4}) == {time(12, 1, 1): 2, time(12, 1, 2): 4}
 
 
 def test_dict(py_or_json):
-    v = py_or_json({'type': 'dict', 'keys': 'time', 'values': 'int'})
+    v = py_or_json({'type': 'dict', 'keys_schema': 'time', 'values_schema': 'int'})
     assert v.validate_test({'12:01:01': 2, '12:01:02': 4}) == {time(12, 1, 1): 2, time(12, 1, 2): 4}
 
 

--- a/tests/validators/test_tuple.py
+++ b/tests/validators/test_tuple.py
@@ -28,7 +28,7 @@ from ..conftest import Err
     ],
 )
 def test_tuple_json(py_or_json, tuple_variant, items, input_value, expected):
-    v = py_or_json({'type': tuple_variant, 'items': items})
+    v = py_or_json({'type': tuple_variant, 'items_schema': items})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=re.escape(expected.message)):
             v.validate_test(input_value)
@@ -45,7 +45,7 @@ def test_tuple_json(py_or_json, tuple_variant, items, input_value, expected):
     ],
 )
 def test_tuple_strict_passes_with_tuple(tuple_variant, items, input, expected):
-    v = SchemaValidator({'type': tuple_variant, 'items': items, 'strict': True})
+    v = SchemaValidator({'type': tuple_variant, 'items_schema': items, 'strict': True})
     assert v.validate_python(input) == expected
 
 
@@ -55,7 +55,7 @@ def test_tuple_strict_passes_with_tuple(tuple_variant, items, input, expected):
 )
 @pytest.mark.parametrize('wrong_coll_type', [list, set, frozenset])
 def test_tuple_strict_fails_without_tuple(wrong_coll_type, tuple_variant, items):
-    v = SchemaValidator({'type': tuple_variant, 'items': items, 'strict': True})
+    v = SchemaValidator({'type': tuple_variant, 'items_schema': items, 'strict': True})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(wrong_coll_type([1, 2, '33']))
     assert exc_info.value.errors() == [
@@ -100,7 +100,7 @@ def test_tuple_var_len_kwargs(kwargs, input_value, expected):
     ],
 )
 def test_tuple_validate(input_value, expected, tuple_variant, items):
-    v = SchemaValidator({'type': tuple_variant, 'items': items})
+    v = SchemaValidator({'type': tuple_variant, 'items_schema': items})
     assert v.validate_python(input_value) == expected
 
 
@@ -116,7 +116,7 @@ def test_tuple_validate(input_value, expected, tuple_variant, items):
     ],
 )
 def test_tuple_var_len_errors(input_value, index):
-    v = SchemaValidator({'type': 'tuple-var-len', 'items': {'type': 'int'}})
+    v = SchemaValidator({'type': 'tuple-var-len', 'items_schema': {'type': 'int'}})
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python(input_value)
     assert exc_info.value.errors() == [
@@ -145,7 +145,7 @@ def test_tuple_var_len_errors(input_value, index):
     ],
 )
 def test_tuple_fix_len_errors(input_value, items, index):
-    v = SchemaValidator({'type': 'tuple-fix-len', 'items': items})
+    v = SchemaValidator({'type': 'tuple-fix-len', 'items_schema': items})
     with pytest.raises(ValidationError) as exc_info:
         assert v.validate_python(input_value)
     assert exc_info.value.errors() == [
@@ -167,7 +167,7 @@ def test_tuple_fix_len_errors(input_value, items, index):
     ids=['input too long', 'input too short'],
 )
 def test_tuple_fix_len_input_and_schemas_len_mismatch(items, input_value, expected):
-    v = SchemaValidator({'type': 'tuple-fix-len', 'items': items})
+    v = SchemaValidator({'type': 'tuple-fix-len', 'items_schema': items})
     with pytest.raises(ValidationError, match=re.escape(expected.message)):
         v.validate_python(input_value)
 
@@ -175,7 +175,7 @@ def test_tuple_fix_len_input_and_schemas_len_mismatch(items, input_value, expect
 @pytest.mark.parametrize('items,expected', [([], Err('Missing schemas for tuple elements'))])
 def test_tuple_fix_len_schema_error(items, expected):
     with pytest.raises(SchemaError, match=expected.message):
-        SchemaValidator({'type': 'tuple-fix-len', 'items': items})
+        SchemaValidator({'type': 'tuple-fix-len', 'items_schema': items})
 
 
 @pytest.mark.parametrize('input_value,expected', [((1, 2, 3), (1, 2, 3)), ([1, 2, 3], [1, 2, 3])])
@@ -219,8 +219,8 @@ def test_union_tuple_var_len(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {'type': 'tuple-var-len', 'items': {'type': 'int'}, 'strict': True},
-                {'type': 'tuple-var-len', 'items': {'type': 'str'}, 'strict': True},
+                {'type': 'tuple-var-len', 'items_schema': {'type': 'int'}, 'strict': True},
+                {'type': 'tuple-var-len', 'items_schema': {'type': 'str'}, 'strict': True},
             ],
         }
     )
@@ -266,8 +266,16 @@ def test_union_tuple_fix_len(input_value, expected):
         {
             'type': 'union',
             'choices': [
-                {'type': 'tuple-fix-len', 'items': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}], 'strict': True},
-                {'type': 'tuple-fix-len', 'items': [{'type': 'str'}, {'type': 'str'}, {'type': 'str'}], 'strict': True},
+                {
+                    'type': 'tuple-fix-len',
+                    'items_schema': [{'type': 'int'}, {'type': 'int'}, {'type': 'int'}],
+                    'strict': True,
+                },
+                {
+                    'type': 'tuple-fix-len',
+                    'items_schema': [{'type': 'str'}, {'type': 'str'}, {'type': 'str'}],
+                    'strict': True,
+                },
             ],
         }
     )
@@ -290,11 +298,11 @@ def test_union_tuple_fix_len(input_value, expected):
 def test_error_building_tuple_with_wrong_items(tuple_variant, items, expected):
 
     with pytest.raises(SchemaError, match=re.escape(expected.message)):
-        SchemaValidator({'type': tuple_variant, 'items': items})
+        SchemaValidator({'type': tuple_variant, 'items_schema': items})
 
 
 def test_tuple_fix_error():
-    v = SchemaValidator({'type': 'tuple-fix-len', 'items': ['int', 'str']})
+    v = SchemaValidator({'type': 'tuple-fix-len', 'items_schema': ['int', 'str']})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python([1])
 

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -40,7 +40,10 @@ class Map(Mapping):
 
 def test_simple():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+        }
     )
 
     assert v.validate_python({'field_a': 123, 'field_b': 1}) == {'field_a': '123', 'field_b': 1}
@@ -49,7 +52,7 @@ def test_simple():
 def test_strict():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'strict': True},
             'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
         }
@@ -68,7 +71,7 @@ def test_strict():
 def test_with_default():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}, 'default': 666}},
         }
@@ -83,14 +86,17 @@ def test_with_default():
 
 def test_missing_error():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}}}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
+        }
     )
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python({'field_a': 123})
     assert (
         str(exc_info.value)
         == """\
-1 validation error for model
+1 validation error for typed-dict
 field_b
   Field required [kind=missing, input_value={'field_a': 123}, input_type=dict]"""
     )
@@ -112,7 +118,7 @@ field_b
 def test_config(config, input_value, expected):
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'a': {'schema': 'int'}, 'b': {'schema': 'int', 'required': False}},
             'config': config,
         }
@@ -129,7 +135,7 @@ def test_config(config, input_value, expected):
 def test_ignore_extra():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'str'}}, 'field_b': {'schema': {'type': 'int'}}},
         }
@@ -144,7 +150,7 @@ def test_ignore_extra():
 def test_forbid_extra():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'str'}}},
             'config': {'extra_behavior': 'forbid'},
@@ -158,7 +164,7 @@ def test_forbid_extra():
 def test_allow_extra():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'str'}}},
             'config': {'extra_behavior': 'allow'},
@@ -174,7 +180,7 @@ def test_allow_extra():
 def test_allow_extra_validate():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'schema': {'type': 'str'}}},
             'extra_validator': {'type': 'int'},
@@ -202,18 +208,23 @@ def test_allow_extra_validate():
 def test_allow_extra_invalid():
     with pytest.raises(SchemaError, match='extra_validator can only be used if extra_behavior=allow'):
         SchemaValidator(
-            {'type': 'model', 'fields': {}, 'extra_validator': {'type': 'int'}, 'config': {'extra_behavior': 'ignore'}}
+            {
+                'type': 'typed-dict',
+                'fields': {},
+                'extra_validator': {'type': 'int'},
+                'config': {'extra_behavior': 'ignore'},
+            }
         )
 
 
 def test_allow_extra_wrong():
     with pytest.raises(SchemaError, match='Invalid extra_behavior: "wrong"'):
-        SchemaValidator({'type': 'model', 'fields': {}, 'config': {'extra_behavior': 'wrong'}})
+        SchemaValidator({'type': 'typed-dict', 'fields': {}, 'config': {'extra_behavior': 'wrong'}})
 
 
 def test_str_config():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}}, 'config': {'str_max_length': 5}}
+        {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'str'}}}, 'config': {'str_max_length': 5}}
     )
     assert v.validate_python({'field_a': 'test'}) == {'field_a': 'test'}
 
@@ -223,7 +234,7 @@ def test_str_config():
 
 def test_validate_assignment():
     v = SchemaValidator(
-        {'type': 'model', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
+        {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
     )
 
     assert v.validate_python({'field_a': 'test'}) == ({'field_a': 'test'}, {'field_a'})
@@ -244,7 +255,7 @@ def test_validate_assignment_functions():
 
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
                 'field_a': {
@@ -274,7 +285,7 @@ def test_validate_assignment_functions():
 
 def test_validate_assignment_ignore_extra():
     v = SchemaValidator(
-        {'type': 'model', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
+        {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'field_a': {'schema': {'type': 'str'}}}}
     )
 
     assert v.validate_python({'field_a': 'test'}) == ({'field_a': 'test'}, {'field_a'})
@@ -294,7 +305,11 @@ def test_validate_assignment_ignore_extra():
 
 def test_validate_assignment_allow_extra():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'schema': {'type': 'str'}}}, 'config': {'extra_behavior': 'allow'}}
+        {
+            'type': 'typed-dict',
+            'fields': {'field_a': {'schema': {'type': 'str'}}},
+            'config': {'extra_behavior': 'allow'},
+        }
     )
 
     assert v.validate_python({'field_a': 'test'}) == {'field_a': 'test'}
@@ -305,7 +320,7 @@ def test_validate_assignment_allow_extra():
 def test_validate_assignment_allow_extra_validate():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'field_a': {'schema': {'type': 'str'}}},
             'extra_validator': {'type': 'int'},
             'config': {'extra_behavior': 'allow'},
@@ -327,7 +342,7 @@ def test_validate_assignment_allow_extra_validate():
 
 
 def test_json_error():
-    v = SchemaValidator({'type': 'model', 'fields': {'field_a': {'schema': {'type': 'list', 'items': 'int'}}}})
+    v = SchemaValidator({'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'list', 'items': 'int'}}}})
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json('{"field_a": [123, "wrong"]}')
 
@@ -343,13 +358,13 @@ def test_json_error():
 
 def test_missing_schema_key():
     with pytest.raises(SchemaError, match='SchemaError: Field "x":\n  KeyError: \'schema\''):
-        SchemaValidator({'type': 'model', 'fields': {'x': {'type': 'str'}}})
+        SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'type': 'str'}}})
 
 
 def test_fields_required_by_default():
     """By default all fields should be required"""
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}}}}
+        {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}}}}
     )
 
     assert v.validate_python({'x': 'pika', 'y': 'chu'}) == {'x': 'pika', 'y': 'chu'}
@@ -365,7 +380,7 @@ def test_fields_required_by_default():
 def test_fields_required_by_default_with_optional():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}, 'required': False}},
         }
@@ -378,7 +393,7 @@ def test_fields_required_by_default_with_optional():
 def test_fields_required_by_default_with_default():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'x': {'schema': {'type': 'str'}}, 'y': {'schema': {'type': 'str'}, 'default': 'bulbi'}},
         }
@@ -392,7 +407,7 @@ def test_all_optional_fields():
     """By default all fields should be optional if `model_full` is set to `False`"""
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'model_full': False},
             'return_fields_set': True,
             'fields': {'x': {'schema': {'type': 'str', 'strict': True}}, 'y': {'schema': {'type': 'str'}}},
@@ -414,7 +429,7 @@ def test_all_optional_fields():
 def test_all_optional_fields_with_required_fields():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'model_full': False},
             'return_fields_set': True,
             'fields': {
@@ -439,12 +454,12 @@ def test_field_required_and_default():
     """A field cannot be required and have a default value"""
     with pytest.raises(SchemaError, match='Field "x": a required field cannot have a default value'):
         SchemaValidator(
-            {'type': 'model', 'fields': {'x': {'schema': {'type': 'str'}, 'required': True, 'default': 'pika'}}}
+            {'type': 'typed-dict', 'fields': {'x': {'schema': {'type': 'str'}, 'required': True, 'default': 'pika'}}}
         )
 
 
 def test_alias(py_or_json):
-    v = py_or_json({'type': 'model', 'fields': {'field_a': {'alias': 'FieldA', 'schema': 'int'}}})
+    v = py_or_json({'type': 'typed-dict', 'fields': {'field_a': {'alias': 'FieldA', 'schema': 'int'}}})
     assert v.validate_test({'FieldA': '123'}) == {'field_a': 123}
     with pytest.raises(ValidationError, match=r'field_a\n +Field required \[kind=missing,'):
         assert v.validate_test({'foobar': '123'})
@@ -455,7 +470,7 @@ def test_alias(py_or_json):
 def test_alias_allow_pop(py_or_json):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'config': {'populate_by_name': True},
             'fields': {'field_a': {'alias': 'FieldA', 'schema': 'int'}},
@@ -480,7 +495,7 @@ def test_alias_allow_pop(py_or_json):
     ids=repr,
 )
 def test_alias_path(py_or_json, input_value, expected):
-    v = py_or_json({'type': 'model', 'fields': {'field_a': {'aliases': [['foo', 'bar']], 'schema': 'int'}}})
+    v = py_or_json({'type': 'typed-dict', 'fields': {'field_a': {'aliases': [['foo', 'bar']], 'schema': 'int'}}})
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=expected.message):
             v.validate_test(input_value)
@@ -508,7 +523,7 @@ def test_alias_path(py_or_json, input_value, expected):
 def test_aliases_path_multiple(py_or_json, input_value, expected):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'field_a': {'aliases': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']], 'schema': 'int'}},
         }
@@ -524,14 +539,16 @@ def test_aliases_path_multiple(py_or_json, input_value, expected):
 
 def test_aliases_debug():
     v = SchemaValidator(
-        {'type': 'model', 'fields': {'field_a': {'aliases': [['foo', 'bar', 'bat'], ['foo', 3]], 'schema': 'int'}}}
+        {'type': 'typed-dict', 'fields': {'field_a': {'aliases': [['foo', 'bar', 'bat'], ['foo', 3]], 'schema': 'int'}}}
     )
-    assert repr(v).startswith('SchemaValidator(name="model", validator=Model(')
+    assert repr(v).startswith('SchemaValidator(name="typed-dict", validator=Model(')
     assert 'PathChoices(' in repr(v)
 
 
 def get_int_key():
-    v = SchemaValidator({'type': 'model', 'fields': {'field_a': {'aliases': [['foo', 3], ['spam']], 'schema': 'int'}}})
+    v = SchemaValidator(
+        {'type': 'typed-dict', 'fields': {'field_a': {'aliases': [['foo', 3], ['spam']], 'schema': 'int'}}}
+    )
     assert v.validate_python({'foo': {3: 33}}) == ({'field_a': 33}, {'field_a'})
 
 
@@ -542,7 +559,7 @@ class GetItemThing:
 
 
 def get_custom_getitem():
-    v = SchemaValidator({'type': 'model', 'fields': {'field_a': {'aliases': [['foo']], 'schema': 'int'}}})
+    v = SchemaValidator({'type': 'typed-dict', 'fields': {'field_a': {'aliases': [['foo']], 'schema': 'int'}}})
     assert v.validate_python(GetItemThing()) == ({'field_a': 321}, {'field_a'})
     assert v.validate_python({'bar': GetItemThing()}) == ({'field_a': 321}, {'field_a'})
 
@@ -551,7 +568,7 @@ def get_custom_getitem():
 def test_paths_allow_by_name(py_or_json, input_value):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'field_a': {'aliases': [['foo', 'bar'], ['foo']], 'schema': 'int'}},
             'config': {'populate_by_name': True},
         }
@@ -574,11 +591,11 @@ def test_paths_allow_by_name(py_or_json, input_value):
 )
 def test_alias_build_error(alias_schema, error):
     with pytest.raises(SchemaError, match=error):
-        SchemaValidator({'type': 'model', 'fields': {'field_a': {'schema': 'int', **alias_schema}}})
+        SchemaValidator({'type': 'typed-dict', 'fields': {'field_a': {'schema': 'int', **alias_schema}}})
 
 
 def test_empty_model():
-    v = SchemaValidator({'type': 'model', 'fields': {}, 'return_fields_set': True})
+    v = SchemaValidator({'type': 'typed-dict', 'fields': {}, 'return_fields_set': True})
     assert v.validate_python({}) == ({}, set())
     with pytest.raises(ValidationError, match=re.escape('Value must be a valid dictionary [kind=dict_type,')):
         v.validate_python('x')
@@ -587,19 +604,19 @@ def test_empty_model():
 def test_model_deep():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {
                 'field_a': {'schema': 'str'},
                 'field_b': {
                     'schema': {
-                        'type': 'model',
+                        'type': 'typed-dict',
                         'return_fields_set': True,
                         'fields': {
                             'field_c': {'schema': 'str'},
                             'field_d': {
                                 'schema': {
-                                    'type': 'model',
+                                    'type': 'typed-dict',
                                     'return_fields_set': True,
                                     'fields': {'field_e': {'schema': 'str'}, 'field_f': {'schema': 'int'}},
                                 }
@@ -668,7 +685,7 @@ class MyDataclass:
 def test_from_attributes(input_value, expected):
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'a': {'schema': 'int'}, 'b': {'schema': 'int'}, 'c': {'schema': 'str'}},
             'config': {'from_attributes': True},
@@ -686,7 +703,7 @@ def test_from_attributes(input_value, expected):
 def test_from_attributes_type_error():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'a': {'schema': 'int'}, 'b': {'schema': 'int'}, 'c': {'schema': 'str'}},
             'config': {'from_attributes': True},
         }
@@ -707,7 +724,7 @@ def test_from_attributes_type_error():
 def test_from_attributes_by_name():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'a': {'schema': 'int', 'alias': 'a_alias'}},
             'config': {'from_attributes': True, 'populate_by_name': True},
@@ -725,7 +742,7 @@ def test_from_attributes_missing():
 
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'a': {'schema': 'int'}, 'b': {'schema': 'int'}, 'c': {'schema': 'str'}},
             'config': {'from_attributes': True},
         }
@@ -755,7 +772,7 @@ def test_from_attributes_error():
 
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'a': {'schema': 'int'}, 'b': {'schema': 'int'}},
             'config': {'from_attributes': True},
         }
@@ -766,7 +783,7 @@ def test_from_attributes_error():
 
     assert exc_info.value.errors() == [
         {
-            'kind': 'model_attribute_error',
+            'kind': 'get_attribute_error',
             'loc': ['b'],
             'message': 'Error extracting attribute: RuntimeError: intentional error',
             'input_value': HasRepr(IsStr(regex='.+Foobar object at.+')),
@@ -814,7 +831,7 @@ def test_from_attributes_extra():
 
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'return_fields_set': True,
             'fields': {'a': {'schema': 'int'}},
             'config': {'from_attributes': True, 'extra_behavior': 'allow'},
@@ -844,7 +861,7 @@ def foobar():
     ids=repr,
 )
 def test_from_attributes_function(input_value, expected):
-    v = SchemaValidator({'type': 'model', 'fields': {'a': {'schema': 'any'}}, 'config': {'from_attributes': True}})
+    v = SchemaValidator({'type': 'typed-dict', 'fields': {'a': {'schema': 'any'}}, 'config': {'from_attributes': True}})
 
     assert v.validate_python(input_value) == expected
 
@@ -859,14 +876,14 @@ def test_from_attributes_error_error():
         def x(self):
             raise BadError('intentional error')
 
-    v = SchemaValidator({'type': 'model', 'fields': {'x': {'schema': 'int'}}, 'config': {'from_attributes': True}})
+    v = SchemaValidator({'type': 'typed-dict', 'fields': {'x': {'schema': 'int'}}, 'config': {'from_attributes': True}})
 
     with pytest.raises(ValidationError) as exc_info:
         v.validate_python(Foobar())
 
     assert exc_info.value.errors() == [
         {
-            'kind': 'model_attribute_error',
+            'kind': 'get_attribute_error',
             'loc': ['x'],
             'message': IsStr(regex=r'Error extracting attribute: \S+\.<locals>\.BadError: <exception str\(\) failed>'),
             'input_value': HasRepr(IsStr(regex='.+Foobar object at.+')),
@@ -884,7 +901,7 @@ def test_from_attributes_error_error():
 
     assert exc_info.value.errors() == [
         {
-            'kind': 'model_attribute_error',
+            'kind': 'get_attribute_error',
             'loc': ['x'],
             'message': 'Error extracting attribute: RuntimeError',
             'input_value': HasRepr(IsStr(regex='.+UnInitError object at.+')),
@@ -914,7 +931,7 @@ def test_from_attributes_error_error():
 def test_from_attributes_path(input_value, expected):
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'my_field': {'aliases': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']], 'schema': 'int'}},
             'config': {'from_attributes': True},
         }
@@ -936,7 +953,7 @@ def test_from_attributes_path_error():
 
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'fields': {'my_field': {'aliases': [['foo', 'bar', 'bat'], ['foo', 3], ['spam']], 'schema': 'int'}},
             'config': {'from_attributes': True},
         }
@@ -946,7 +963,7 @@ def test_from_attributes_path_error():
 
     assert exc_info.value.errors() == [
         {
-            'kind': 'model_attribute_error',
+            'kind': 'get_attribute_error',
             'loc': ['my_field'],
             'message': 'Error extracting attribute: RuntimeError: intentional error',
             'input_value': HasRepr(IsStr(regex='.+PropertyError object at.+')),
@@ -958,7 +975,7 @@ def test_from_attributes_path_error():
 def test_alias_extra(py_or_json):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'extra_behavior': 'allow'},
             'fields': {'field_a': {'aliases': [['FieldA'], ['foo', 2]], 'schema': 'int'}},
         }
@@ -983,7 +1000,7 @@ def test_alias_extra(py_or_json):
 def test_alias_extra_from_attributes():
     v = SchemaValidator(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'extra_behavior': 'allow', 'from_attributes': True},
             'fields': {'field_a': {'aliases': [['FieldA'], ['foo', 2]], 'schema': 'int'}},
         }
@@ -997,7 +1014,7 @@ def test_alias_extra_from_attributes():
 def test_alias_extra_by_name(py_or_json):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'extra_behavior': 'allow', 'from_attributes': True, 'populate_by_name': True},
             'fields': {'field_a': {'alias': 'FieldA', 'schema': 'int'}},
         }
@@ -1011,7 +1028,7 @@ def test_alias_extra_by_name(py_or_json):
 def test_alias_extra_forbid(py_or_json):
     v = py_or_json(
         {
-            'type': 'model',
+            'type': 'typed-dict',
             'config': {'extra_behavior': 'forbid'},
             'fields': {'field_a': {'alias': 'FieldA', 'schema': 'int'}},
         }

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -342,7 +342,9 @@ def test_validate_assignment_allow_extra_validate():
 
 
 def test_json_error():
-    v = SchemaValidator({'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'list', 'items': 'int'}}}})
+    v = SchemaValidator(
+        {'type': 'typed-dict', 'fields': {'field_a': {'schema': {'type': 'list', 'items_schema': 'int'}}}}
+    )
     with pytest.raises(ValidationError) as exc_info:
         v.validate_json('{"field_a": [123, "wrong"]}')
 

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -60,7 +60,7 @@ class TestModelClass:
                         'type': 'model-class',
                         'class_type': self.ModelA,
                         'model': {
-                            'type': 'model',
+                            'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
                         },
@@ -69,7 +69,7 @@ class TestModelClass:
                         'type': 'model-class',
                         'class_type': self.ModelB,
                         'model': {
-                            'type': 'model',
+                            'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'c': {'schema': {'type': 'int'}}, 'd': {'schema': {'type': 'str'}}},
                         },
@@ -124,7 +124,7 @@ class TestModelClassSimilar:
                         'type': 'model-class',
                         'class_type': self.ModelA,
                         'model': {
-                            'type': 'model',
+                            'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
                         },
@@ -133,7 +133,7 @@ class TestModelClassSimilar:
                         'type': 'model-class',
                         'class_type': self.ModelB,
                         'model': {
-                            'type': 'model',
+                            'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {
                                 'a': {'schema': {'type': 'int'}},

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -59,7 +59,7 @@ class TestModelClass:
                     {
                         'type': 'model-class',
                         'class_type': self.ModelA,
-                        'model': {
+                        'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
@@ -68,7 +68,7 @@ class TestModelClass:
                     {
                         'type': 'model-class',
                         'class_type': self.ModelB,
-                        'model': {
+                        'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'c': {'schema': {'type': 'int'}}, 'd': {'schema': {'type': 'str'}}},
@@ -123,7 +123,7 @@ class TestModelClassSimilar:
                     {
                         'type': 'model-class',
                         'class_type': self.ModelA,
-                        'model': {
+                        'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {'a': {'schema': {'type': 'int'}}, 'b': {'schema': {'type': 'str'}}},
@@ -132,7 +132,7 @@ class TestModelClassSimilar:
                     {
                         'type': 'model-class',
                         'class_type': self.ModelB,
-                        'model': {
+                        'schema': {
                             'type': 'typed-dict',
                             'return_fields_set': True,
                             'fields': {

--- a/tests/validators/test_union.py
+++ b/tests/validators/test_union.py
@@ -194,7 +194,10 @@ def test_union_list_bool_int():
     v = SchemaValidator(
         {
             'type': 'union',
-            'choices': [{'type': 'list', 'items': {'type': 'bool'}}, {'type': 'list', 'items': {'type': 'int'}}],
+            'choices': [
+                {'type': 'list', 'items_schema': {'type': 'bool'}},
+                {'type': 'list', 'items_schema': {'type': 'int'}},
+            ],
         }
     )
     assert v.validate_python(['true', True, 'no']) == [True, True, False]


### PR DESCRIPTION
* `model` -> `typed_dict` fix #116 
* `items` -> `items_schema` on list, set, frozenset, tuple
* `model` -> `schema` on class_model
* `keys` -> `keys_schema` and `values` -> `values_schema` on dict
* prevent accidental `schema` on plain functions