### PR TITLE
Upload wasm wheels to github release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,3 +353,16 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_token }}
+
+      - name: get wasm dist artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: wasm_wheels
+          path: wasm
+
+      - name: upload to github release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            wasm/*.whl
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}


### PR DESCRIPTION
> Since pypi won't at present accept wasm wheels, could we add those files (and indeed all wheels) to the release in github? Then it looks from [micropip's docs](https://pyodide.org/en/stable/usage/api/micropip-api.html) like we could install pydantic-core from the github URL?

_Originally posted by @samuelcolvin in https://github.com/samuelcolvin/pydantic-core/issues/106#issuecomment-1162840440_