### PR TITLE
fix wasm build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
     env:
       PYODIDE_VERSION: '0.21.0-alpha.2'
       PYTHON_VERSION: '3.10.2'
+      EMSCRIPTEN_VERSION: '3.1.14'
       NODE_VERSION: 18
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ docs/_build/
 tests/package.json
 tests/package-lock.json
 tests/node_modules
-/.hypothesis/
+.hypothesis/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import importlib.util
 import json
 import os
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -89,23 +88,3 @@ def import_execute(request, tmp_work_path: Path):
             print('KeyboardInterrupt')
 
     return _import_execute
-
-
-if sys.platform == 'emscripten':
-    # we have to stub pytest-benchmark since it can't currently be used with webassembly/emscripten
-
-    @pytest.fixture
-    def benchmark():
-        def result(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        return result
-
-    def pytest_configure(config):
-        config.addinivalue_line('markers', 'benchmark: pytest-benchmark stub, ignored')
-
-    def pytest_addoption(parser):
-        parser.addoption('--benchmark-columns', action='store', default='-', help='pytest-benchmark stub, ignored')
-        parser.addoption('--benchmark-group-by', action='store', default='-', help='pytest-benchmark stub, ignored')
-        parser.addoption('--benchmark-warmup', action='store', default='-', help='pytest-benchmark stub, ignored')
-        parser.addoption('--benchmark-disable', action='store_true', default='-', help='pytest-benchmark stub, ignored')

--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -82,7 +82,7 @@ function setupStreams(FS, TTY){
 async function main() {
   const wheelName = await findWheel(distDir);
   const wheelURL = `file:${distDir}/${wheelName}`;
-
+  let errcode = 0;
   try {
     pyodide = await loadPyodide();
     const FS = pyodide.FS;
@@ -93,16 +93,17 @@ async function main() {
     await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
     const micropip = pyodide.pyimport('micropip');
     await micropip.install('dirty-equals');
+    await micropip.install('hypothesis');
     await micropip.install('pytest-speed');
     await micropip.install(wheelURL);
     const pytest = pyodide.pyimport('pytest');
     FS.chdir("/test_dir");
     errcode = pytest.main();
-    process.exit(errcode);
   } catch (e) {
     console.error(e);
     process.exit(1);
   }
+  process.exit(errcode);
 }
 
 main();

--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -93,6 +93,7 @@ async function main() {
     await pyodide.loadPackage(['micropip', 'pytest', 'pytz']);
     const micropip = pyodide.pyimport('micropip');
     await micropip.install('dirty-equals');
+    await micropip.install('pytest-speed');
     await micropip.install(wheelURL);
     const pytest = pyodide.pyimport('pytest');
     FS.chdir("/test_dir");

--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -98,6 +98,7 @@ async function main() {
     const pytest = pyodide.pyimport('pytest');
     FS.chdir("/test_dir");
     errcode = pytest.main();
+    process.exit(errcode);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -20,6 +21,7 @@ def test_datetime_datetime(datetime_schema, data):
     assert datetime_schema.validate_python(data) == data
 
 
+@pytest.mark.skipif(sys.platform == 'emscripten', reason='OverflowError, see pyodide/pyodide#2841')
 @given(strategies.integers(min_value=-11_676_096_000, max_value=253_402_300_799_000))
 def test_datetime_int(datetime_schema, data):
     if abs(data) > 20_000_000_000:


### PR DESCRIPTION
try using pytest-speed as a substitute for pytest-benchmark for wasm builds.