### PR TITLE
Functional tagged unions

### DIFF
--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time, timedelta
-from typing import Any, Callable, Dict, List, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired, Required
@@ -194,7 +194,7 @@ class UnionSchema(TypedDict, total=False):
 class TaggedUnionSchema(TypedDict):
     type: Literal['tagged-union']
     choices: Dict[str, Schema]
-    tag_key: Union[str, List[Union[str, int]], List[List[Union[str, int]]]]
+    tag_key: Union[str, List[Union[str, int]], List[List[Union[str, int]]], Callable[[Any], Optional[str]]]
     strict: NotRequired[bool]
     ref: NotRequired[str]
 

--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -194,7 +194,7 @@ class UnionSchema(TypedDict, total=False):
 class TaggedUnionSchema(TypedDict):
     type: Literal['tagged-union']
     choices: Dict[str, Schema]
-    tag_key: Union[str, List[Union[str, int]], List[List[Union[str, int]]], Callable[[Any], Optional[str]]]
+    discriminator: Union[str, List[Union[str, int]], List[List[Union[str, int]]], Callable[[Any], Optional[str]]]
     strict: NotRequired[bool]
     ref: NotRequired[str]
 

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -207,13 +207,15 @@ pub enum ErrorKind {
     CallableType,
     // ---------------------
     // union errors
-    #[strum(message = "Input tag \"{tag}\" from {discriminator} must match one of the expected tags: {expected_tags}")]
+    #[strum(
+        message = "Input tag '{tag}' found using {discriminator} does not match any of the expected tags: {expected_tags}"
+    )]
     UnionTagInvalid {
         discriminator: String,
         tag: String,
         expected_tags: String,
     },
-    #[strum(message = "Unable to extract tag {discriminator}")]
+    #[strum(message = "Unable to extract tag using discriminator {discriminator}")]
     UnionTagNotFound { discriminator: String },
 }
 

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -207,8 +207,14 @@ pub enum ErrorKind {
     CallableType,
     // ---------------------
     // union errors
-    #[strum(message = "Input key \"{key}\" must match one of the allowed tags {tags}")]
-    UnionTagNotFound { key: String, tags: String },
+    #[strum(message = "Input tag \"{tag}\" from {source} must match one of the expected tags: {expected_tags}")]
+    UnionTagInvalid {
+        source: String,
+        tag: String,
+        expected_tags: String,
+    },
+    #[strum(message = "Unable to extract tag {source}")]
+    UnionTagNotFound { source: String },
 }
 
 macro_rules! render {
@@ -287,7 +293,12 @@ impl ErrorKind {
             Self::DateTimeObjectInvalid { error } => render!(template, error),
             Self::TimeDeltaParsing { error } => render!(template, error),
             Self::IsInstanceOf { class } => render!(template, class),
-            Self::UnionTagNotFound { key, tags } => render!(template, key, tags),
+            Self::UnionTagInvalid {
+                source,
+                tag,
+                expected_tags,
+            } => render!(template, source, tag, expected_tags),
+            Self::UnionTagNotFound { source } => render!(template, source),
             _ => template.to_string(),
         }
     }
@@ -335,7 +346,12 @@ impl ErrorKind {
             Self::DateTimeObjectInvalid { error } => py_dict!(py, error),
             Self::TimeDeltaParsing { error } => py_dict!(py, error),
             Self::IsInstanceOf { class } => py_dict!(py, class),
-            Self::UnionTagNotFound { key, tags } => py_dict!(py, key, tags),
+            Self::UnionTagInvalid {
+                source,
+                tag,
+                expected_tags,
+            } => py_dict!(py, source, tag, expected_tags),
+            Self::UnionTagNotFound { source } => py_dict!(py, source),
             _ => Ok(None),
         }
     }

--- a/src/errors/kinds.rs
+++ b/src/errors/kinds.rs
@@ -207,14 +207,14 @@ pub enum ErrorKind {
     CallableType,
     // ---------------------
     // union errors
-    #[strum(message = "Input tag \"{tag}\" from {source} must match one of the expected tags: {expected_tags}")]
+    #[strum(message = "Input tag \"{tag}\" from {discriminator} must match one of the expected tags: {expected_tags}")]
     UnionTagInvalid {
-        source: String,
+        discriminator: String,
         tag: String,
         expected_tags: String,
     },
-    #[strum(message = "Unable to extract tag {source}")]
-    UnionTagNotFound { source: String },
+    #[strum(message = "Unable to extract tag {discriminator}")]
+    UnionTagNotFound { discriminator: String },
 }
 
 macro_rules! render {
@@ -294,11 +294,11 @@ impl ErrorKind {
             Self::TimeDeltaParsing { error } => render!(template, error),
             Self::IsInstanceOf { class } => render!(template, class),
             Self::UnionTagInvalid {
-                source,
+                discriminator,
                 tag,
                 expected_tags,
-            } => render!(template, source, tag, expected_tags),
-            Self::UnionTagNotFound { source } => render!(template, source),
+            } => render!(template, discriminator, tag, expected_tags),
+            Self::UnionTagNotFound { discriminator } => render!(template, discriminator),
             _ => template.to_string(),
         }
     }
@@ -347,11 +347,11 @@ impl ErrorKind {
             Self::TimeDeltaParsing { error } => py_dict!(py, error),
             Self::IsInstanceOf { class } => py_dict!(py, class),
             Self::UnionTagInvalid {
-                source,
+                discriminator,
                 tag,
                 expected_tags,
-            } => py_dict!(py, source, tag, expected_tags),
-            Self::UnionTagNotFound { source } => py_dict!(py, source),
+            } => py_dict!(py, discriminator, tag, expected_tags),
+            Self::UnionTagNotFound { discriminator } => py_dict!(py, discriminator),
             _ => Ok(None),
         }
     }

--- a/src/errors/line_error.rs
+++ b/src/errors/line_error.rs
@@ -1,4 +1,6 @@
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::PyDowncastError;
 
 use crate::input::{Input, JsonInput};
 
@@ -17,6 +19,12 @@ pub enum ValError<'a> {
 impl<'a> From<PyErr> for ValError<'a> {
     fn from(py_err: PyErr) -> Self {
         Self::InternalErr(py_err)
+    }
+}
+
+impl<'a> From<PyDowncastError<'_>> for ValError<'a> {
+    fn from(py_downcast: PyDowncastError) -> Self {
+        Self::InternalErr(PyTypeError::new_err(py_downcast.to_string()))
     }
 }
 

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -43,42 +43,38 @@ macro_rules! py_string {
 }
 
 impl LookupKey {
-    pub fn from_py(py: Python, field: &PyDict, alt_alias: Option<&str>, name: &str) -> PyResult<Option<Self>> {
-        if let Some(value) = field.get_item(name) {
-            if let Ok(alias_py) = value.cast_as::<PyString>() {
-                let alias: String = alias_py.extract()?;
-                let alias_py: Py<PyString> = alias_py.into_py(py);
-                match alt_alias {
-                    Some(alt_alias) => Ok(Some(LookupKey::Choice(
-                        alias,
-                        alt_alias.to_string(),
-                        alias_py,
-                        py_string!(py, alt_alias),
-                    ))),
-                    None => Ok(Some(LookupKey::Simple(alias, alias_py))),
-                }
-            } else {
-                let list: &PyList = value.cast_as()?;
-                let first = match list.get_item(0) {
-                    Ok(v) => v,
-                    Err(_) => return py_error!("\"{}\" must have at least one element", name),
-                };
-                let mut locs: Vec<Path> = if first.cast_as::<PyString>().is_ok() {
-                    // list of strings rather than list of lists
-                    vec![Self::path_choice(py, list)?]
-                } else {
-                    list.iter()
-                        .map(|obj| Self::path_choice(py, obj))
-                        .collect::<PyResult<_>>()?
-                };
-
-                if let Some(alt_alias) = alt_alias {
-                    locs.push(vec![PathItem::S(alt_alias.to_string(), py_string!(py, alt_alias))])
-                }
-                Ok(Some(LookupKey::PathChoices(locs)))
+    pub fn from_py(py: Python, value: &PyAny, alt_alias: Option<&str>) -> PyResult<Self> {
+        if let Ok(alias_py) = value.cast_as::<PyString>() {
+            let alias: String = alias_py.extract()?;
+            let alias_py: Py<PyString> = alias_py.into_py(py);
+            match alt_alias {
+                Some(alt_alias) => Ok(LookupKey::Choice(
+                    alias,
+                    alt_alias.to_string(),
+                    alias_py,
+                    py_string!(py, alt_alias),
+                )),
+                None => Ok(LookupKey::Simple(alias, alias_py)),
             }
         } else {
-            Ok(None)
+            let list: &PyList = value.cast_as()?;
+            let first = match list.get_item(0) {
+                Ok(v) => v,
+                Err(_) => return py_error!("Lookup paths must have at least one element"),
+            };
+            let mut locs: Vec<Path> = if first.cast_as::<PyString>().is_ok() {
+                // list of strings rather than list of lists
+                vec![Self::path_choice(py, list)?]
+            } else {
+                list.iter()
+                    .map(|obj| Self::path_choice(py, obj))
+                    .collect::<PyResult<_>>()?
+            };
+
+            if let Some(alt_alias) = alt_alias {
+                locs.push(vec![PathItem::S(alt_alias.to_string(), py_string!(py, alt_alias))])
+            }
+            Ok(LookupKey::PathChoices(locs))
         }
     }
 

--- a/src/lookup_key.rs
+++ b/src/lookup_key.rs
@@ -25,8 +25,8 @@ pub enum LookupKey {
 impl fmt::Display for LookupKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Simple(key, _) => write!(f, "{}", key),
-            Self::Choice(key1, key2, _, _) => write!(f, "{} | {}", key1, key2),
+            Self::Simple(key, _) => write!(f, "'{}'", key),
+            Self::Choice(key1, key2, _, _) => write!(f, "'{}' | '{}'", key1, key2),
             Self::PathChoices(paths) => write!(
                 f,
                 "{}",
@@ -215,7 +215,7 @@ pub enum PathItem {
 impl fmt::Display for PathItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::S(key, _) => write!(f, "{}", key),
+            Self::S(key, _) => write!(f, "'{}'", key),
             Self::I(key) => write!(f, "{}", key),
         }
     }

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -93,9 +93,11 @@ impl BuildValidator for TypedDictValidator {
                     (default, default_factory) => (default, default_factory),
                 };
 
-            let alt_alias = if populate_by_name { Some(field_name) } else { None };
-            let lookup_key = match LookupKey::from_py(py, field_info, alt_alias, "alias")? {
-                Some(key) => key,
+            let lookup_key = match field_info.get_item("alias") {
+                Some(alias) => {
+                    let alt_alias = if populate_by_name { Some(field_name) } else { None };
+                    LookupKey::from_py(py, alias, alt_alias)?
+                }
                 None => LookupKey::from_string(py, field_name),
             };
             fields.push(TypedDictField {

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -230,7 +230,7 @@ impl Validator for TaggedUnionValidator {
                 if result.is_none(py) {
                     Err(self.tag_not_found(input))
                 } else {
-                    let result_str: &PyString = result.cast_as(py).unwrap();
+                    let result_str: &PyString = result.cast_as(py)?;
                     self.find_call_validator(py, result_str.to_string_lossy(), input, extra, slots, recursion_guard)
                 }
             }

--- a/src/validators/union.rs
+++ b/src/validators/union.rs
@@ -150,7 +150,7 @@ impl BuildValidator for TaggedUnionValidator {
             discriminator = Discriminator::Function(raw_discriminator.to_object(py));
         } else {
             let lookup_key = LookupKey::from_py(py, raw_discriminator, None)?;
-            discriminator_repr = format!("\"{}\"", lookup_key);
+            discriminator_repr = lookup_key.to_string();
             discriminator = Discriminator::LookupKey(lookup_key);
         };
 
@@ -165,10 +165,10 @@ impl BuildValidator for TaggedUnionValidator {
             let validator = build_validator(value, config, build_context)?.0;
             if first {
                 first = false;
-                write!(tags_repr, r#""{}""#, tag).unwrap();
+                write!(tags_repr, "'{}'", tag).unwrap();
                 descr.push_str(validator.get_name());
             } else {
-                write!(tags_repr, r#", "{}""#, tag).unwrap();
+                write!(tags_repr, ", '{}'", tag).unwrap();
                 // no spaces in get_name() output to make loc easy to read
                 write!(descr, ",{}", validator.get_name()).unwrap();
             }

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -17,7 +17,7 @@ def test_schema_typing() -> None:
     SchemaValidator(schema)
     schema: Schema = {
         'type': 'tagged-union',
-        'tag_key': 'kind',
+        'discriminator': 'kind',
         'choices': {
             'apple': {'type': 'typed-dict', 'fields': {'pips': {'schema': {'type': 'int'}}}},
             'banana': {'type': 'typed-dict', 'fields': {'curvature': {'schema': {'type': 'float'}}}},

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -262,3 +262,9 @@ def test_use_ref():
     assert v.validate_python({'foobar': 'apple', 'a': 'apple'}) == {'a': 'apple'}
     assert v.validate_python({'foobar': 'apple2', 'a': 'apple'}) == {'a': 'apple'}
     assert v.validate_python({'foobar': 'banana', 'b': 'banana'}) == {'b': 'banana'}
+
+
+def test_downcast_error():
+    v = SchemaValidator({'type': 'tagged-union', 'discriminator': lambda x: 123, 'choices': {'str': 'str'}})
+    with pytest.raises(TypeError, match="'int' object cannot be converted to 'PyString'"):
+        v.validate_python('x')

--- a/tests/validators/test_tagged_union.py
+++ b/tests/validators/test_tagged_union.py
@@ -103,6 +103,7 @@ def test_simple_tagged_union(py_and_json: PyAndJson, input_value, expected):
             },
         }
     )
+    assert 'discriminator: LookupKey' in repr(v.validator)
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=expected.message) as exc_info:
             v.validate_test(input_value)
@@ -218,6 +219,7 @@ def test_discriminator_function(py_and_json: PyAndJson, input_value, expected):
             'choices': {'str': {'type': 'literal', 'expected': ['foo', 'bar']}, 'int': {'type': 'int'}},
         }
     )
+    assert 'discriminator: Function' in repr(v.validator)
     if isinstance(expected, Err):
         with pytest.raises(ValidationError, match=expected.message) as exc_info:
             v.validate_python(input_value)

--- a/tests/validators/test_typed_dict.py
+++ b/tests/validators/test_typed_dict.py
@@ -573,7 +573,7 @@ def test_paths_allow_by_name(py_and_json: PyAndJson, input_value):
     'alias_schema,error',
     [
         ({'alias': ['foo', ['bar']]}, 'TypeError: Alias path items must be with a string or int'),
-        ({'alias': []}, '"alias" must have at least one element'),
+        ({'alias': []}, 'Lookup paths must have at least one element'),
         ({'alias': [[]]}, 'Each alias path must have at least one element'),
         ({'alias': [123]}, "TypeError: 'int' object cannot be converted to 'PyList'"),
         ({'alias': [[[]]]}, 'TypeError: Alias path items must be with a string or int'),


### PR DESCRIPTION
Allow using a function as descriminator for tagged unions.

Required for #131, also very useful.