### PR TITLE
more sequence improvements

### DIFF
--- a/src/validators/frozenset.rs
+++ b/src/validators/frozenset.rs
@@ -3,7 +3,7 @@ use pyo3::types::{PyDict, PyFrozenSet};
 
 use crate::build_tools::SchemaDict;
 use crate::errors::ValResult;
-use crate::input::Input;
+use crate::input::{GenericSequence, Input};
 use crate::recursion_guard::RecursionGuard;
 
 use super::list::sequence_build_function;
@@ -37,7 +37,10 @@ impl Validator for FrozenSetValidator {
 
         let output = match self.item_validator {
             Some(ref v) => seq.validate_to_vec(py, length, v, extra, slots, recursion_guard)?,
-            None => seq.to_vec(py),
+            None => match seq {
+                GenericSequence::FrozenSet(f_set) => return Ok(f_set.into_py(py)),
+                _ => seq.to_vec(py),
+            },
         };
         Ok(PyFrozenSet::new(py, &output)?.into_py(py))
     }

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -3,7 +3,7 @@ use pyo3::types::PyDict;
 
 use crate::build_tools::SchemaDict;
 use crate::errors::ValResult;
-use crate::input::Input;
+use crate::input::{GenericSequence, Input};
 use crate::recursion_guard::RecursionGuard;
 
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
@@ -69,7 +69,10 @@ impl Validator for ListValidator {
 
         let output = match self.item_validator {
             Some(ref v) => seq.validate_to_vec(py, length, v, extra, slots, recursion_guard)?,
-            None => seq.to_vec(py),
+            None => match seq {
+                GenericSequence::List(list) => return Ok(list.into_py(py)),
+                _ => seq.to_vec(py),
+            },
         };
         Ok(output.into_py(py))
     }

--- a/src/validators/set.rs
+++ b/src/validators/set.rs
@@ -3,7 +3,7 @@ use pyo3::types::{PyDict, PySet};
 
 use crate::build_tools::SchemaDict;
 use crate::errors::ValResult;
-use crate::input::Input;
+use crate::input::{GenericSequence, Input};
 use crate::recursion_guard::RecursionGuard;
 
 use super::list::sequence_build_function;
@@ -37,7 +37,10 @@ impl Validator for SetValidator {
 
         let output = match self.item_validator {
             Some(ref v) => seq.validate_to_vec(py, length, v, extra, slots, recursion_guard)?,
-            None => seq.to_vec(py),
+            None => match seq {
+                GenericSequence::Set(set) => return Ok(set.into_py(py)),
+                _ => seq.to_vec(py),
+            },
         };
         Ok(PySet::new(py, &output)?.into_py(py))
     }

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -38,7 +38,10 @@ impl Validator for TupleVarLenValidator {
 
         let output = match self.item_validator {
             Some(ref v) => seq.validate_to_vec(py, length, v, extra, slots, recursion_guard)?,
-            None => seq.to_vec(py),
+            None => match seq {
+                GenericSequence::Tuple(tuple) => return Ok(tuple.into_py(py)),
+                _ => seq.to_vec(py),
+            },
         };
         Ok(PyTuple::new(py, &output).into_py(py))
     }


### PR DESCRIPTION
I meant to do this in #179, but forgot.

Now that's what I call a speed improvement:

```
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃  Group            ┃  Benchmark                 ┃  Before (ns/iter)  ┃  After (ns/iter)  ┃   Change  ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│  List[TypedDict]  │  list_of_dict_models_core  │           11690.0  │          11288.5  │   -3.43%  │
├───────────────────┼────────────────────────────┼────────────────────┼───────────────────┼───────────┤
│  List             │  list_of_ints_core_py      │          232374.2  │         224456.1  │   -3.41%  │
├───────────────────┼────────────────────────────┼────────────────────┼───────────────────┼───────────┤
│  List JSON        │  list_of_ints_core_json    │           98281.2  │          96440.4  │   -1.87%  │
├───────────────────┼────────────────────────────┼────────────────────┼───────────────────┼───────────┤
│  List[Any]        │  list_of_any_core_py       │           24720.2  │            227.0  │  -99.08%  │
├───────────────────┼────────────────────────────┼────────────────────┼───────────────────┼───────────┤
│  List[Nullable]   │  list_of_nullable_core     │           20435.2  │          20085.3  │   -1.71%  │
└───────────────────┴────────────────────────────┴────────────────────┴───────────────────┴───────────┘
```

Wit this `list` and similar are passed straight through (`output_list is input_list`) but I think that's fine, pydantic-core (and pydantic v1.X) don't make any guarantees that values are copied, so even less copying seems fine to me.

@PrettyWood @tiangolo what do you think?

I guess in theory we could add a copy mode, but it would be pretty complicated to implement consistently. I don't think most people care?