### PR TITLE
we can use recent typing for stub file or pure type hint

### DIFF
--- a/pydantic_core/_pydantic_core.pyi
+++ b/pydantic_core/_pydantic_core.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List, Optional, TypedDict, Union
+from typing import Any, TypedDict
 
 from pydantic_core._types import Config, Schema
 
@@ -12,39 +12,37 @@ __all__ = '__version__', 'SchemaValidator', 'SchemaError', 'ValidationError', 'P
 __version__: str
 
 class SchemaValidator:
-    def __init__(self, schema: Schema, config: Optional[Config] = None) -> None: ...
-    def validate_python(self, input: Any, strict: Optional[bool] = None, context: Any = None) -> Any: ...
-    def isinstance_python(self, input: Any, strict: Optional[bool] = None, context: Any = None) -> bool: ...
+    def __init__(self, schema: Schema, config: 'Config | None' = None) -> None: ...
+    def validate_python(self, input: Any, strict: 'bool | None' = None, context: Any = None) -> Any: ...
+    def isinstance_python(self, input: Any, strict: 'bool | None' = None, context: Any = None) -> bool: ...
     def validate_json(
-        self, input: Union[str, bytes, bytearray], strict: Optional[bool] = None, context: Any = None
+        self, input: 'str | bytes | bytearray', strict: 'bool | None' = None, context: Any = None
     ) -> Any: ...
     def isinstance_json(
-        self, input: Union[str, bytes, bytearray], strict: Optional[bool] = None, context: Any = None
+        self, input: 'str | bytes | bytearray', strict: 'bool | None' = None, context: Any = None
     ) -> bool: ...
-    def validate_assignment(self, field: str, input: Any, data: Dict[str, Any]) -> Dict[str, Any]: ...
+    def validate_assignment(self, field: str, input: Any, data: 'dict[str, Any]') -> 'dict[str, Any]': ...
 
 class SchemaError(Exception):
     pass
 
 class ErrorDetails(TypedDict):
     kind: str
-    loc: List[Union[int, str]]
+    loc: 'list[int | str]'
     message: str
     input_value: Any
-    context: NotRequired[Dict[str, Any]]
+    context: NotRequired['dict[str, Any]']
 
 class ValidationError(ValueError):
     title: str
 
     def error_count(self) -> int: ...
-    def errors(self) -> List[ErrorDetails]: ...
+    def errors(self) -> 'list[ErrorDetails]': ...
 
 class PydanticValueError(ValueError):
     kind: str
     message_template: str
-    context: Optional[Dict[str, Union[str, int]]]
+    context: 'dict[str, str | int] | None'
 
-    def __init__(
-        self, kind: str, message_template: str, context: Optional[Dict[str, Union[str, int]]] = None
-    ) -> None: ...
+    def __init__(self, kind: str, message_template: str, context: 'dict[str, str | int] | None' = None) -> None: ...
     def message(self) -> str: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 import pytest
 from hypothesis import settings
@@ -41,20 +41,20 @@ class Err:
 
 
 class PyAndJsonValidator:
-    def __init__(self, schema, validator_type: Optional[Literal['json', 'python']] = None):
+    def __init__(self, schema, validator_type: 'Literal["json", "python"] | None' = None):
         self.validator = SchemaValidator(schema)
         self.validator_type = validator_type
 
-    def validate_python(self, py_input, strict: Optional[bool] = None):
+    def validate_python(self, py_input, strict: 'bool | None' = None):
         return self.validator.validate_python(py_input, strict)
 
-    def validate_test(self, py_input, strict: Optional[bool] = None):
+    def validate_test(self, py_input, strict: 'bool | None' = None):
         if self.validator_type == 'json':
             return self.validator.validate_json(json.dumps(py_input), strict)
         elif self.validator_type == 'python':
             return self.validator.validate_python(py_input, strict)
 
-    def isinstance_test(self, py_input, strict: Optional[bool] = None):
+    def isinstance_test(self, py_input, strict: 'bool | None' = None):
         if self.validator_type == 'json':
             return self.validator.isinstance_json(json.dumps(py_input), strict)
         elif self.validator_type == 'python':
@@ -87,7 +87,7 @@ def tmp_work_path(tmp_path: Path):
 
 @pytest.fixture
 def import_execute(request, tmp_work_path: Path):
-    def _import_execute(source: str, *, custom_module_name: Optional[str] = None):
+    def _import_execute(source: str, *, custom_module_name: 'str | None' = None):
         example_bash_file = tmp_work_path / 'example.sh'
         example_bash_file.write_text('#!/bin/sh\necho testing')
         example_bash_file.chmod(0o755)


### PR DESCRIPTION
As discussed on twitter it works great to already use new typing in quotes as long as it doesn't need to be interpreted (obviously)
So we can at least use that in stub file or in function signatures but not on `TypedDict`, `BaseModel`, ...

I tried with python 3.8 and it works perfectly (with `pyright`, in `vscode` and `pycharm`)