### PR TITLE
Functions inside models

### DIFF
--- a/pydantic_core/_types.py
+++ b/pydantic_core/_types.py
@@ -112,7 +112,7 @@ class LiteralSchema(TypedDict):
 class ModelClassSchema(TypedDict):
     type: Literal['model-class']
     class_type: type
-    schema: TypedDictSchema
+    schema: Schema
     strict: NotRequired[bool]
     ref: NotRequired[str]
     config: NotRequired[Config]

--- a/src/validators/arguments.rs
+++ b/src/validators/arguments.rs
@@ -76,7 +76,7 @@ impl BuildValidator for ArgumentsValidator {
                 .get_as_req(intern!(py, "schema"))
                 .map_err(|err| SchemaError::new_err(format!("Argument \"{}\":\n  {}", name, err)))?;
 
-            let (validator, _) = build_validator(schema, config, build_context)?;
+            let validator = build_validator(schema, config, build_context)?;
 
             let default = arg.get_as(intern!(py, "default"))?;
             let default_factory = arg.get_as(intern!(py, "default_factory"))?;
@@ -102,11 +102,11 @@ impl BuildValidator for ArgumentsValidator {
             arguments,
             positional_args_count,
             var_args_validator: match schema.get_item(intern!(py, "var_args_schema")) {
-                Some(v) => Some(Box::new(build_validator(v, config, build_context)?.0)),
+                Some(v) => Some(Box::new(build_validator(v, config, build_context)?)),
                 None => None,
             },
             var_kwargs_validator: match schema.get_item(intern!(py, "var_kwargs_schema")) {
-                Some(v) => Some(Box::new(build_validator(v, config, build_context)?.0)),
+                Some(v) => Some(Box::new(build_validator(v, config, build_context)?)),
                 None => None,
             },
         }

--- a/src/validators/dict.rs
+++ b/src/validators/dict.rs
@@ -30,11 +30,11 @@ impl BuildValidator for DictValidator {
     ) -> PyResult<CombinedValidator> {
         let py = schema.py();
         let key_validator = match schema.get_item(intern!(py, "keys_schema")) {
-            Some(schema) => Box::new(build_validator(schema, config, build_context)?.0),
+            Some(schema) => Box::new(build_validator(schema, config, build_context)?),
             None => Box::new(AnyValidator::build(schema, config, build_context)?),
         };
         let value_validator = match schema.get_item(intern!(py, "values_schema")) {
-            Some(d) => Box::new(build_validator(d, config, build_context)?.0),
+            Some(d) => Box::new(build_validator(d, config, build_context)?),
             None => Box::new(AnyValidator::build(schema, config, build_context)?),
         };
         let name = format!(

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -3,14 +3,13 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 
-use crate::build_tools::{py_error, SchemaDict};
+use crate::build_tools::SchemaDict;
 use crate::errors::{ErrorKind, PydanticValueError, ValError, ValResult, ValidationError};
 use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
 
 use super::{build_validator, BuildContext, BuildValidator, CombinedValidator, Extra, Validator};
 
-#[derive(Debug)]
 pub struct FunctionBuilder;
 
 impl BuildValidator for FunctionBuilder {
@@ -25,9 +24,9 @@ impl BuildValidator for FunctionBuilder {
         match mode {
             "before" => FunctionBeforeValidator::build(schema, config, build_context),
             "after" => FunctionAfterValidator::build(schema, config, build_context),
-            "plain" => FunctionPlainValidator::build(schema, config),
             "wrap" => FunctionWrapValidator::build(schema, config, build_context),
-            _ => py_error!("Unexpected function mode {:?}", mode),
+            // must be "plain"
+            _ => FunctionPlainValidator::build(schema, config),
         }
     }
 }
@@ -165,18 +164,14 @@ pub struct FunctionPlainValidator {
 impl FunctionPlainValidator {
     pub fn build(schema: &PyDict, config: Option<&PyDict>) -> PyResult<CombinedValidator> {
         let py = schema.py();
-        if schema.get_item(intern!(py, "schema")).is_some() {
-            py_error!("Plain functions should not include a sub-schema")
-        } else {
-            Ok(Self {
-                func: schema.get_as_req::<&PyAny>(intern!(py, "function"))?.into_py(py),
-                config: match config {
-                    Some(c) => c.into(),
-                    None => py.None(),
-                },
-            }
-            .into())
+        Ok(Self {
+            func: schema.get_as_req::<&PyAny>(intern!(py, "function"))?.into_py(py),
+            config: match config {
+                Some(c) => c.into(),
+                None => py.None(),
+            },
         }
+        .into())
     }
 }
 

--- a/src/validators/function.rs
+++ b/src/validators/function.rs
@@ -47,7 +47,7 @@ macro_rules! impl_build {
                 build_context: &mut BuildContext,
             ) -> PyResult<CombinedValidator> {
                 let py = schema.py();
-                let validator = build_validator(schema.get_as_req(intern!(py, "schema"))?, config, build_context)?.0;
+                let validator = build_validator(schema.get_as_req(intern!(py, "schema"))?, config, build_context)?;
                 let name = format!("{}[{}]", $name, validator.get_name());
                 Ok(Self {
                     validator: Box::new(validator),
@@ -110,6 +110,10 @@ impl Validator for FunctionBeforeValidator {
         &self.name
     }
 
+    fn ask(&self, question: &str) -> bool {
+        self.validator.ask(question)
+    }
+
     fn complete(&mut self, build_context: &BuildContext) -> PyResult<()> {
         self.validator.complete(build_context)
     }
@@ -141,6 +145,10 @@ impl Validator for FunctionAfterValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn ask(&self, question: &str) -> bool {
+        self.validator.ask(question)
     }
 
     fn complete(&mut self, build_context: &BuildContext) -> PyResult<()> {
@@ -234,6 +242,10 @@ impl Validator for FunctionWrapValidator {
 
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn ask(&self, question: &str) -> bool {
+        self.validator.ask(question)
     }
 
     fn complete(&mut self, build_context: &BuildContext) -> PyResult<()> {

--- a/src/validators/list.rs
+++ b/src/validators/list.rs
@@ -28,7 +28,7 @@ macro_rules! generic_list_like_build {
         ) -> PyResult<CombinedValidator> {
             let py = schema.py();
             let item_validator = match schema.get_item(pyo3::intern!(py, "items_schema")) {
-                Some(d) => Some(Box::new(build_validator(d, config, build_context)?.0)),
+                Some(d) => Some(Box::new(build_validator(d, config, build_context)?)),
                 None => None,
             };
             let inner_name = item_validator.as_ref().map(|v| v.get_name()).unwrap_or("any");

--- a/src/validators/nullable.rs
+++ b/src/validators/nullable.rs
@@ -24,7 +24,7 @@ impl BuildValidator for NullableValidator {
         build_context: &mut BuildContext,
     ) -> PyResult<CombinedValidator> {
         let schema: &PyAny = schema.get_as_req(intern!(schema.py(), "schema"))?;
-        let validator = Box::new(build_validator(schema, config, build_context)?.0);
+        let validator = Box::new(build_validator(schema, config, build_context)?);
         let name = format!("{}[{}]", Self::EXPECTED_TYPE, validator.get_name());
         Ok(Self { validator, name }.into())
     }

--- a/src/validators/tuple.rs
+++ b/src/validators/tuple.rs
@@ -93,7 +93,7 @@ impl TuplePositionalValidator {
         let items: &PyList = schema.get_as_req(intern!(py, "items_schema"))?;
         let validators: Vec<CombinedValidator> = items
             .iter()
-            .map(|item| build_validator(item, config, build_context).map(|result| result.0))
+            .map(|item| build_validator(item, config, build_context))
             .collect::<PyResult<Vec<CombinedValidator>>>()?;
 
         let descr = validators.iter().map(|v| v.get_name()).collect::<Vec<_>>().join(", ");
@@ -101,7 +101,7 @@ impl TuplePositionalValidator {
             strict: is_strict(schema, config)?,
             items_validators: validators,
             extra_validator: match schema.get_item(intern!(py, "extra_schema")) {
-                Some(v) => Some(Box::new(build_validator(v, config, build_context)?.0)),
+                Some(v) => Some(Box::new(build_validator(v, config, build_context)?)),
                 None => None,
             },
             name: format!("tuple[{}]", descr),

--- a/src/validators/typed_dict.rs
+++ b/src/validators/typed_dict.rs
@@ -94,7 +94,7 @@ impl BuildValidator for TypedDictValidator {
         let extra_validator = match schema.get_item(intern!(py, "extra_validator")) {
             Some(v) => {
                 if check_extra && !forbid_extra {
-                    Some(Box::new(build_validator(v, config, build_context)?.0))
+                    Some(Box::new(build_validator(v, config, build_context)?))
                 } else {
                     return py_error!("extra_validator can only be used if extra_behavior=allow");
                 }
@@ -175,7 +175,7 @@ impl BuildValidator for TypedDictValidator {
                 lookup_key,
                 name_pystring: PyString::intern(py, field_name).into(),
                 validator: match build_validator(schema, config, build_context) {
-                    Ok((v, _)) => v,
+                    Ok(v) => v,
                     Err(err) => return py_error!("Field \"{}\":\n  {}", field_name, err),
                 },
                 required,
@@ -374,6 +374,14 @@ impl Validator for TypedDictValidator {
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
+    }
+
+    fn ask(&self, question: &str) -> bool {
+        if question == "return_fields_set" {
+            self.return_fields_set
+        } else {
+            false
+        }
     }
 
     fn complete(&mut self, build_context: &BuildContext) -> PyResult<()> {

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -34,7 +34,7 @@ class TestBenchmarkSimpleModel:
         return PydanticModel
 
     @pytest.fixture(scope='class')
-    def core_validator(self):
+    def core_validator_fs(self):
         class CoreModel:
             __slots__ = '__dict__', '__fields_set__'
 
@@ -55,6 +55,27 @@ class TestBenchmarkSimpleModel:
             }
         )
 
+    @pytest.fixture(scope='class')
+    def core_validator_not_fs(self):
+        class CoreModel:
+            __slots__ = '__dict__', '__fields_set__'
+
+        return SchemaValidator(
+            {
+                'type': 'model-class',
+                'class_type': CoreModel,
+                'schema': {
+                    'type': 'typed-dict',
+                    'fields': {
+                        'name': {'schema': {'type': 'str'}},
+                        'age': {'schema': {'type': 'int'}},
+                        'friends': {'schema': {'type': 'list', 'items_schema': 'int'}},
+                        'settings': {'schema': {'type': 'dict', 'keys_schema': 'str', 'values_schema': 'float'}},
+                    },
+                },
+            }
+        )
+
     data = {'name': 'John', 'age': 42, 'friends': list(range(200)), 'settings': {f'v_{i}': i / 2.0 for i in range(50)}}
 
     @skip_pydantic
@@ -62,9 +83,21 @@ class TestBenchmarkSimpleModel:
     def test_pyd_python(self, pydantic_model, benchmark):
         benchmark(pydantic_model.parse_obj, self.data)
 
-    @pytest.mark.benchmark(group='simple model - python')
-    def test_core_python(self, core_validator, benchmark):
-        benchmark(core_validator.validate_python, self.data)
+    @pytest.mark.benchmark(group='simple model FS - python')
+    def test_core_python_fs(self, core_validator_fs, benchmark):
+        m = core_validator_fs.validate_python(self.data)
+        assert m.name == 'John'
+        assert m.__dict__.keys() == {'name', 'age', 'friends', 'settings'}
+        assert m.__fields_set__ == {'name', 'age', 'friends', 'settings'}
+        benchmark(core_validator_fs.validate_python, self.data)
+
+    @pytest.mark.benchmark(group='simple model not FS - python')
+    def test_core_python_not_fs(self, core_validator_not_fs, benchmark):
+        m = core_validator_not_fs.validate_python(self.data)
+        assert m.name == 'John'
+        assert m.__dict__.keys() == {'name', 'age', 'friends', 'settings'}
+        assert not hasattr(m, '__fields_set__')
+        benchmark(core_validator_not_fs.validate_python, self.data)
 
     @skip_pydantic
     @pytest.mark.benchmark(group='simple model - JSON')
@@ -76,10 +109,15 @@ class TestBenchmarkSimpleModel:
             obj = json.loads(json_data)
             return pydantic_model.parse_obj(obj)
 
-    @pytest.mark.benchmark(group='simple model - JSON')
-    def test_core_json(self, core_validator, benchmark):
+    @pytest.mark.benchmark(group='simple model FS - JSON')
+    def test_core_json_fs(self, core_validator_fs, benchmark):
         json_data = json.dumps(self.data)
-        benchmark(core_validator.validate_json, json_data)
+        benchmark(core_validator_fs.validate_json, json_data)
+
+    @pytest.mark.benchmark(group='simple model not FS - JSON')
+    def test_core_json_not_fs(self, core_validator_not_fs, benchmark):
+        json_data = json.dumps(self.data)
+        benchmark(core_validator_not_fs.validate_json, json_data)
 
 
 bool_cases = [True, False, 0, 1, '0', '1', 'true', 'false', 'True', 'False']

--- a/tests/benchmarks/test_micro_benchmarks.py
+++ b/tests/benchmarks/test_micro_benchmarks.py
@@ -83,7 +83,7 @@ class TestBenchmarkSimpleModel:
     def test_pyd_python(self, pydantic_model, benchmark):
         benchmark(pydantic_model.parse_obj, self.data)
 
-    @pytest.mark.benchmark(group='simple model FS - python')
+    @pytest.mark.benchmark(group='simple model - python')
     def test_core_python_fs(self, core_validator_fs, benchmark):
         m = core_validator_fs.validate_python(self.data)
         assert m.name == 'John'
@@ -91,7 +91,7 @@ class TestBenchmarkSimpleModel:
         assert m.__fields_set__ == {'name', 'age', 'friends', 'settings'}
         benchmark(core_validator_fs.validate_python, self.data)
 
-    @pytest.mark.benchmark(group='simple model not FS - python')
+    @pytest.mark.benchmark(group='simple model - python')
     def test_core_python_not_fs(self, core_validator_not_fs, benchmark):
         m = core_validator_not_fs.validate_python(self.data)
         assert m.name == 'John'
@@ -109,12 +109,12 @@ class TestBenchmarkSimpleModel:
             obj = json.loads(json_data)
             return pydantic_model.parse_obj(obj)
 
-    @pytest.mark.benchmark(group='simple model FS - JSON')
+    @pytest.mark.benchmark(group='simple model - JSON')
     def test_core_json_fs(self, core_validator_fs, benchmark):
         json_data = json.dumps(self.data)
         benchmark(core_validator_fs.validate_json, json_data)
 
-    @pytest.mark.benchmark(group='simple model not FS - JSON')
+    @pytest.mark.benchmark(group='simple model - JSON')
     def test_core_json_not_fs(self, core_validator_not_fs, benchmark):
         json_data = json.dumps(self.data)
         benchmark(core_validator_not_fs.validate_json, json_data)

--- a/tests/validators/test_model_class.py
+++ b/tests/validators/test_model_class.py
@@ -99,6 +99,125 @@ def test_model_class_root_validator():
     assert 'test_model_class_root_validator.<locals>.MyModel' in m
 
 
+@pytest.mark.parametrize('mode', ['before', 'after', 'wrap'])
+@pytest.mark.parametrize('return_fields_set', [True, False])
+def test_function_ask(mode, return_fields_set):
+    class MyModel:
+        __slots__ = '__dict__', '__fields_set__'
+
+    def f(input_value, **kwargs):
+        return input_value
+
+    v = SchemaValidator(
+        {
+            'type': 'model-class',
+            'class_type': MyModel,
+            'schema': {
+                'type': 'function',
+                'mode': mode,
+                'function': f,
+                'schema': {
+                    'type': 'typed-dict',
+                    'return_fields_set': return_fields_set,
+                    'fields': {'field_a': {'schema': {'type': 'str'}}},
+                },
+            },
+        }
+    )
+    expect_fields_set = re.search('expect_fields_set:(true|false)', plain_repr(v)).group(1)
+    assert expect_fields_set == str(return_fields_set).lower()
+
+
+def test_function_plain_ask():
+    class MyModel:
+        pass
+
+    def f(input_value, **kwargs):
+        return input_value
+
+    v = SchemaValidator(
+        {'type': 'model-class', 'class_type': MyModel, 'schema': {'type': 'function', 'mode': 'plain', 'function': f}}
+    )
+    assert 'expect_fields_set:false' in plain_repr(v)
+    m = v.validate_python({'field_a': 'test'})
+    assert isinstance(m, MyModel)
+    assert m.__dict__ == {'field_a': 'test'}
+    assert not hasattr(m, '__fields_set__')
+
+
+def test_union_sub_schema():
+    class MyModel:
+        __slots__ = '__dict__', '__fields_set__'
+
+    v = SchemaValidator(
+        {
+            'type': 'model-class',
+            'class_type': MyModel,
+            'schema': {
+                'type': 'union',
+                'choices': [
+                    {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'foo': {'schema': 'int'}}},
+                    {'type': 'typed-dict', 'return_fields_set': True, 'fields': {'bar': {'schema': 'int'}}},
+                ],
+            },
+        }
+    )
+    assert 'expect_fields_set:true' in plain_repr(v)
+    m = v.validate_python({'foo': '123'})
+    assert isinstance(m, MyModel)
+    assert m.__dict__ == {'foo': 123}
+    assert m.__fields_set__ == {'foo'}
+    m = v.validate_python({'bar': '123'})
+    assert isinstance(m, MyModel)
+    assert m.__dict__ == {'bar': 123}
+    assert m.__fields_set__ == {'bar'}
+
+
+def test_tagged_union_sub_schema():
+    class MyModel:
+        pass
+
+    v = SchemaValidator(
+        {
+            'type': 'model-class',
+            'class_type': MyModel,
+            'schema': {
+                'type': 'tagged-union',
+                'discriminator': 'foo',
+                'choices': {
+                    'apple': {'type': 'typed-dict', 'fields': {'foo': {'schema': 'str'}, 'bar': {'schema': 'int'}}},
+                    'banana': {
+                        'type': 'typed-dict',
+                        'return_fields_set': True,
+                        'fields': {
+                            'foo': {'schema': 'str'},
+                            'spam': {'schema': {'type': 'list', 'items_schema': 'int'}},
+                        },
+                    },
+                },
+            },
+        }
+    )
+    assert 'expect_fields_set:false' in plain_repr(v)  # because only one choice has return_fields_set=True!
+    m = v.validate_python({'foo': 'apple', 'bar': '123'})
+    assert isinstance(m, MyModel)
+    assert m.__dict__ == {'foo': 'apple', 'bar': 123}
+    assert not hasattr(m, '__fields_set__')
+    # error because banana has return_fields_set=True
+    with pytest.raises(TypeError, match="__dict__ must be set to a dictionary, not a 'tuple'"):
+        v.validate_python({'foo': 'banana', 'spam': [1, 2, 3]})
+
+
+def test_bad_sub_schema():
+    class MyModel:
+        pass
+
+    v = SchemaValidator({'type': 'model-class', 'class_type': MyModel, 'schema': 'int'})
+    assert 'expect_fields_set:false' in plain_repr(v)
+    with pytest.raises(TypeError, match="__dict__ must be set to a dictionary, not a 'int'"):
+        v.validate_python(123)
+
+
 def test_model_class_function_after():
     class MyModel:
         __slots__ = '__dict__', '__fields_set__'
@@ -284,7 +403,8 @@ def test_revalidate():
         def __init__(self, a, b, fields_set):
             self.field_a = a
             self.field_b = b
-            self.__fields_set__ = fields_set
+            if fields_set is not None:
+                self.__fields_set__ = fields_set
 
     v = SchemaValidator(
         {
@@ -324,6 +444,13 @@ def test_revalidate():
             'input_value': 'not int',
         }
     ]
+
+    m5 = MyModel('x', 5, None)
+    m6 = v.validate_python(m5)
+    assert isinstance(m6, MyModel)
+    assert m6 is not m5
+    assert m6.__dict__ == {'field_a': 'x', 'field_b': 5}
+    assert m6.__fields_set__ == {'field_a', 'field_b'}
 
 
 def test_revalidate_extra():

--- a/tests/validators/test_model_class.py
+++ b/tests/validators/test_model_class.py
@@ -204,7 +204,8 @@ def test_tagged_union_sub_schema():
     assert m.__dict__ == {'foo': 'apple', 'bar': 123}
     assert not hasattr(m, '__fields_set__')
     # error because banana has return_fields_set=True
-    with pytest.raises(TypeError, match="__dict__ must be set to a dictionary, not a 'tuple'"):
+    # "__dict__ must be set to a dictionary, not a 'tuple'" on cpython, different on pypy
+    with pytest.raises(TypeError):
         v.validate_python({'foo': 'banana', 'spam': [1, 2, 3]})
 
 
@@ -214,7 +215,7 @@ def test_bad_sub_schema():
 
     v = SchemaValidator({'type': 'model-class', 'class_type': MyModel, 'schema': 'int'})
     assert 'expect_fields_set:false' in plain_repr(v)
-    with pytest.raises(TypeError, match="__dict__ must be set to a dictionary, not a 'int'"):
+    with pytest.raises(TypeError):
         v.validate_python(123)
 
 


### PR DESCRIPTION
fix #198, also make `return_fields_set` optional on typeddicts when used within `model-class` validators